### PR TITLE
updated to use SHOW DATABASES

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION='0.0.1-b2'
+VERSION='0.0.2'
 PYTHON_REQUIRES='3.7'
 
 packagedata=dict()

--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -71,12 +71,14 @@ class SnowflakeAdapter(BaseSourceAdapter):
     MATERIALIZATION_MAPPINGS = {"BASE TABLE": mz.TABLE,
                                 "VIEW": mz.VIEW}
 
-    def get_all_databases_statement(self)->str:
-        return """ SELECT DISTINCT database_name
-FROM "UTIL_DB"."INFORMATION_SCHEMA"."DATABASES"
-WHERE is_transient = 'NO'
-AND database_name <> 'UTIL_DB'
-"""
+    def get_all_databases(self) -> str:
+        """ Use the SHOW api to get all the available db structures."""
+        logger.debug('Collecting databases from snowflake...')
+        show_result = tuple(self._safe_query("SHOW TERSE DATABASES")['name'].tolist())
+        databases = list(set(show_result))
+        logger.debug(f'Done. Found {len(databases)} databases.')
+        return databases
+
 
     def population_count_statement(self,relation:Relation)->str:
         """creates the count * statement for a relation

--- a/tests/integration/snowflake/test_end_to_end.py
+++ b/tests/integration/snowflake/test_end_to_end.py
@@ -40,9 +40,9 @@ def test_reports_full_catalog_start(end_to_end):
     result_lines = end_to_end
     assert any_appearance_of('Assessing full catalog...',result_lines)
 
-def test_finds_11_relations(end_to_end):
+def test_finds_36_relations(end_to_end):
     result_lines= end_to_end
-    assert any_appearance_of('Identified a total of 11 relations to sample based on the specified configurations.',result_lines)
+    assert any_appearance_of('Identified a total of 36 relations to sample based on the specified configurations.',result_lines)
 
 def test_replicates_order_items(end_to_end):
     result_lines = end_to_end


### PR DESCRIPTION
## Why? 
This closes out #40.

## What Changes?
Snowflake adapter uses SHOW DATABASE to grab databases. this should work without access to `UTIL_DB`.