### PR TITLE
Better errors messages (input validation)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,22 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+
+  build-and-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install docker-compose
+      run: pip install --no-cache-dir docker-compose
+    - name: Build the Docker image
+      run: docker-compose up -d -f docker-compose.yml
+    - name: Run Test
+      run: docker-compose exec -f docker-compose.yml -T snowshu py.test --cov=snowshu tests/unit

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,7 @@ tabulate==0.8.6
 psycopg2-binary==2.8.4
 scipy==1.4.1
 overrides==3.1.0
+jsonschema==3.2.0
 
 
 #SNOWFLAKE

--- a/snowshu/adapters/target_adapters/base_target_adapter.py
+++ b/snowshu/adapters/target_adapters/base_target_adapter.py
@@ -227,9 +227,9 @@ AS
             for db,schema in unique_schemas:
                 conn = self.get_connection(database_override=db,
                                            schema_override=schema)
-                logger.info(f'Applying function {function} to "{db}"."{schema}"...')
+                logger.debug(f'Applying function {function} to "{db}"."{schema}"...')
                 conn.execute(function_sql)
-                logger.info(f'Function {function} added.')
+                logger.debug(f'Function {function} added.')
         except FileNotFoundError:
             logger.info(f'Function {function} is not implemented for target {self.CLASSNAME}.')
             return    

--- a/snowshu/adapters/target_adapters/postgres_adapter/postgres_adapter.py
+++ b/snowshu/adapters/target_adapters/postgres_adapter/postgres_adapter.py
@@ -84,7 +84,7 @@ class PostgresAdapter(BaseTargetAdapter):
         def statement_runner(statement:str):
             logger.info(f'executing statement `{statement}...`')
             response=conn.execute(statement)
-            logger.info('Executed.')
+            logger.debug('Executed.')
         
         for db in unique_databases:
             conn = self.get_connection(database_override=db)

--- a/snowshu/core/configuration_parser.py
+++ b/snowshu/core/configuration_parser.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 from snowshu.core.utils import fetch_adapter,correct_case
+import os
 import yaml
+import jsonschema
+from jsonschema.exceptions import ValidationError
 from typing import Union, TextIO, List, Optional,Type,Any
 from snowshu.logger import Logger
 from snowshu.configs import DEFAULT_THREAD_COUNT, \
@@ -81,7 +84,8 @@ class Configuration:
 
 class ConfigurationParser:
 
-    def _get_dict_from_anything(self, dict_like_object:Union[str,'StringIO',dict])->dict:
+    def _get_dict_from_anything(self, dict_like_object:Union[str,'StringIO',dict],
+                                **kwargs)->dict:
         """Returns dict from path, io object or dict.  
         
         Returns:
@@ -94,8 +98,41 @@ class ConfigurationParser:
             try:
                 return yaml.safe_load(dict_like_object.read())
             except AttributeError:
-                with open(dict_like_object,'r') as f:
-                    return yaml.safe_load(f.read())
+                return self._load_and_verify_file(dict_like_object, **kwargs)
+
+    def _load_and_verify_file(self,
+                              file_path,
+                              verify: bool = True,
+                              templates_path: Path = Path(os.path.dirname(__file__)).parent / 'templates',
+                              schema_path: Path = None):
+        logger.debug("Parsing file at %s", file_path)
+        if not schema_path:
+            schema_path = templates_path / f'{Path(file_path).stem}_schema.json'
+        if not os.path.isfile(schema_path):
+            logger.warning("Loading from %s, but no schema (%s) found to verify it.",
+                            file_path, schema_path)
+            verify = False
+
+        # Load data
+        try:
+            with open(file_path, 'r') as instance_file:
+                instance = yaml.safe_load(instance_file.read())
+        except FileNotFoundError as exc:
+            exc.strerror = f'Error when loading YAML config at {file_path}' + exc.strerror
+            raise
+
+        # Load schema and verify
+        if verify:
+            try:
+                with open(schema_path) as schema_file:
+                    schema = yaml.safe_load(schema_file.read())
+                jsonschema.validate(instance=instance, schema=schema)
+            except ValidationError as exc:
+                logger.error('Invalid object %s', exc)
+                raise exc
+
+        return instance
+
 
     def _set_default(self,
                      dict_from:dict,
@@ -214,7 +251,8 @@ class ConfigurationParser:
                     self._build_relationships(rel)) for rel in specified_relations]
     
     def _build_adapter_profile(self,section:str,
-                               full_configs:Union[str,'StringIO',dict])->AdapterProfile:
+                               full_configs:Union[str,'StringIO',dict],
+                               **kwargs)->AdapterProfile:
         profile=full_configs[section]['profile']
         credentials=full_configs['credpath']
         
@@ -230,9 +268,13 @@ class ConfigurationParser:
                 raise KeyError(profile)
             except KeyError as e:
                 raise ValueError(f'Credentials missing required section: {e}')
-        profile_dict=lookup_profile_from_creds(self._get_dict_from_anything(credentials),
-                                               profile,
-                                               section)
+        try:
+            profile_dict=lookup_profile_from_creds(self._get_dict_from_anything(credentials, **kwargs),
+                                                profile,
+                                                section)
+        except FileNotFoundError as err:
+            err.strerror = "Credentials specified in replica.yml not found. " + err.strerror
+            raise
 
         adapter=fetch_adapter(profile_dict['adapter'],section)
 

--- a/snowshu/logger.py
+++ b/snowshu/logger.py
@@ -6,6 +6,8 @@ from coloredlogs import ColoredFormatter
 from typing import Optional
 from logging.handlers import RotatingFileHandler
 
+# Tone down snowflake.connector log noise by only outputting warnings and higher level messages
+logging.getLogger('snowflake.connector').setLevel(logging.WARNING)
 
 def duration(start: int) -> str:
     dur = round(time.time() - start, 2)

--- a/snowshu/templates/credentials_schema.json
+++ b/snowshu/templates/credentials_schema.json
@@ -1,5 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Validation schema for credentials.yml",
+  "description": "credentials.yml store the source connection information.",
   "type": "object",
   "properties": {
     "sources": {

--- a/snowshu/templates/credentials_schema.json
+++ b/snowshu/templates/credentials_schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "sources": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "account": {
+              "type": "string"
+            },
+            "adapter": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "user": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "account",
+            "adapter",
+            "database",
+            "name",
+            "password",
+            "user"
+          ]
+        }
+      ]
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "sources",
+    "version"
+  ]
+}
+

--- a/snowshu/templates/replica_schema.json
+++ b/snowshu/templates/replica_schema.json
@@ -1,0 +1,236 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "credpath": {
+      "type": "string"
+    },
+    "long_description": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "short_description": {
+      "type": "string"
+    },
+    "source": {
+      "$ref": "#/definitions/source"
+    },
+    "target": {
+      "$ref": "#/definitions/target"
+    },
+    "threads": {
+      "type": "integer"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "credpath",
+    "name",
+    "short_description",
+    "source",
+    "target",
+    "threads",
+    "version"
+  ],
+  "definitions": {
+    "target": {
+      "type": "object",
+      "properties": {
+        "adapter": { "type": "string"}
+      },
+      "required": [
+          "adapter"
+      ]
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "general_relations": {
+          "$ref": "#/definitions/general_relations"
+        },
+        "include_outliers": {
+          "type": "boolean"
+        },
+        "profile": {
+          "type": "string"
+        },
+        "sampling": {
+          "type": "string"
+        },
+        "specified_relations": {
+          "$ref": "#/definitions/specified_relations"
+        }
+      },
+      "required": [
+        "general_relations",
+        "include_outliers",
+        "profile",
+        "sampling"
+      ]
+    },
+    "general_relations": {
+      "type": "object",
+      "properties": {
+        "databases": {
+          "$ref": "#/definitions/_database"
+        }
+      },
+      "required": [
+        "databases"
+      ]
+    },
+    "_database": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "pattern": {
+              "type": "string"
+            },
+            "schemas": {
+              "$ref": "#/definitions/_db_schema"
+            }
+          },
+          "required": [
+            "pattern",
+            "schemas"
+          ]
+        }
+      ]
+    },
+    "_db_schema": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "pattern": {
+              "type": "string"
+            },
+            "relations": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "required": [
+            "pattern",
+            "relations"
+          ]
+        }
+      ]
+    },
+    "specified_relations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/single_specified_relation"
+      }
+    },
+    "single_specified_relation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "database": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "relation": {
+          "type": "string"
+        },
+        "unsampled": {
+          "type": "boolean"
+        },
+        "relationships": {
+          "$ref": "#/definitions/relationship_object"
+        }
+      },
+      "required": [
+        "database",
+        "schema",
+        "relation"
+      ]
+    },
+    "relationship_object": {
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/directional"
+        },
+        {
+          "$ref": "#/definitions/bidirectional"
+        }
+      ]
+    },
+    "directional": {
+      "type": "object",
+      "properties": {
+        "directional": {
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/_directional_relationship_object"
+            }
+          ]
+        }
+      },
+      "required":[
+        "directional"
+      ]
+    },
+    "bidirectional": {
+      "type": "object",
+      "properties": {
+        "bidirectional": {
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/_directional_relationship_object"
+            }
+          ]
+        }
+      },
+      "required": [
+        "bidirectional"
+      ]
+    },
+    "_directional_relationship_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "local_attribute": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "relation": {
+          "type": "string"
+        },
+        "remote_attribute": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "local_attribute",
+        "database",
+        "schema",
+        "relation",
+        "remote_attribute"
+      ]
+    }
+  }
+}

--- a/snowshu/templates/replica_schema.json
+++ b/snowshu/templates/replica_schema.json
@@ -1,5 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Validation schema for replica.yml",
+  "description": "Based on https://snowshu.readthedocs.io/en/latest/user_documentation/replica_dot_yaml_file.html",
   "type": "object",
   "properties": {
     "credpath": {
@@ -30,10 +32,8 @@
   "required": [
     "credpath",
     "name",
-    "short_description",
     "source",
     "target",
-    "threads",
     "version"
   ],
   "definitions": {
@@ -56,6 +56,10 @@
         "include_outliers": {
           "type": "boolean"
         },
+        "max_outliers": {
+          "type": "integer",
+          "default": 100
+        },
         "profile": {
           "type": "string"
         },
@@ -68,7 +72,6 @@
       },
       "required": [
         "general_relations",
-        "include_outliers",
         "profile",
         "sampling"
       ]
@@ -153,6 +156,9 @@
         },
         "relationships": {
           "$ref": "#/definitions/relationship_object"
+        },
+        "sampling": {
+          "$ref": "#/definitions/sampling_object"
         }
       },
       "required": [
@@ -231,6 +237,56 @@
         "relation",
         "remote_attribute"
       ]
+    },
+    "sampling_object": {
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/default_sampling"
+        },
+        {
+          "$ref": "#/definitions/brute_force_sampling"
+        }
+      ]
+    },
+    "default_sampling": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "$ref": "#/definitions/_sampling_params"
+        }
+      },
+      "required": [
+        "default"
+      ]
+    },
+    "brute_force_sampling": {
+      "type": "object",
+      "properties": {
+        "brute_force": {
+          "$ref": "#/definitions/_sampling_params"
+        }
+      },
+      "required": [
+        "brute_force"
+      ]
+    },
+    "_sampling_params": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "number"
+      },
+      "properties": {
+        "margin_of_error": {
+          "type": "number"
+        },
+        "confidence": {
+          "type": "number"
+        },
+        "min_sample_size": {
+          "type": "integer"
+        }
+      }
     }
   }
 }

--- a/tests/integration/snowflake/test_end_to_end.py
+++ b/tests/integration/snowflake/test_end_to_end.py
@@ -17,6 +17,7 @@ from snowshu.core.main import cli
 BASE_CONN='postgresql://snowshu:snowshu@integration-test:9999/{}'
 SNOWSHU_META_STRING=BASE_CONN.format('snowshu')
 SNOWSHU_DEVELOPMENT_STRING=BASE_CONN.format('snowshu_development')
+DOCKER_SPIN_UP_TIMEOUT = 10
 
 @pytest.fixture(scope="session", autouse=True)
 def end_to_end(docker_flush_session):
@@ -30,8 +31,35 @@ def end_to_end(docker_flush_session):
                           name='integration-test',
                           network='snowshu',
                           detach=True)
-    time.sleep(5) # the replica needs a second to initialize
+    wait_for_spin_up() # the replica needs a second to initialize
     return create_output
+
+def wait_for_spin_up(container_name: str = None) -> docker.models.containers.Container:
+    """ Waits for the system to get the snowshu related docker container ready.
+
+        Args:
+            container_name: Specific container name. If not provided, waits for the containers
+                            created by default settings in the test module
+    """
+    start_time = time.time()
+    client = docker.from_env()
+    snowshu_related_containers = ('snowshu_replica_',
+                                  'integration-test',
+                                  'snowshu_target',)
+    possible_containers = (container_name,) if container_name else snowshu_related_containers
+    found_container = None
+    while not found_container and time.time() - start_time < DOCKER_SPIN_UP_TIMEOUT:
+        for container in possible_containers:
+            try:
+                found_container = client.containers.get(container)
+            except docker.errors.NotFound:
+                pass
+        time.sleep(1)
+
+    if not found_container:
+        raise Exception("Unable to start up docker containers.")
+
+    return found_container
 
 def any_appearance_of(string,strings):
     return any([string in line for line in strings])

--- a/tests/integration/test_docker_end_to_end.py
+++ b/tests/integration/test_docker_end_to_end.py
@@ -5,6 +5,7 @@ from tests.common import rand_string
 from sqlalchemy import create_engine
 from snowshu.core.docker import SnowShuDocker
 from snowshu.adapters.target_adapters import PostgresAdapter
+from tests.integration.snowflake.test_end_to_end import wait_for_spin_up
 
 from snowshu.logger import Logger
 Logger().set_log_level(0)
@@ -32,7 +33,7 @@ def test_creates_replica(docker_flush):
          'POSTGRES_DB=snowshu', ])
 
     # load test data
-    time.sleep(5)  # give pg a moment to spin up all the way
+    wait_for_spin_up()  # give pg a moment to spin up all the way
     engine = create_engine(
         'postgresql://snowshu:snowshu@snowshu_target:9999/snowshu')
     engine.execute(
@@ -54,7 +55,7 @@ def test_creates_replica(docker_flush):
                           name=TEST_NAME,
                           network='snowshu',
                           detach=True)
-    time.sleep(5)  # give pg a moment to spin up all the way
+    wait_for_spin_up(container_name=TEST_NAME)  # give pg a moment to spin up all the way
     engine = create_engine(
         f'postgresql://snowshu:snowshu@{TEST_NAME}:9999/snowshu')
     res = engine.execute(f'SELECT * FROM {TEST_TABLE}').fetchall()

--- a/tests/integration/test_docker_end_to_end.py
+++ b/tests/integration/test_docker_end_to_end.py
@@ -5,7 +5,7 @@ from tests.common import rand_string
 from sqlalchemy import create_engine
 from snowshu.core.docker import SnowShuDocker
 from snowshu.adapters.target_adapters import PostgresAdapter
-from tests.integration.snowflake.test_end_to_end import wait_for_spin_up
+from tests.integration.snowflake.test_end_to_end import DOCKER_SPIN_UP_TIMEOUT
 
 from snowshu.logger import Logger
 Logger().set_log_level(0)
@@ -33,7 +33,7 @@ def test_creates_replica(docker_flush):
          'POSTGRES_DB=snowshu', ])
 
     # load test data
-    wait_for_spin_up()  # give pg a moment to spin up all the way
+    time.sleep(DOCKER_SPIN_UP_TIMEOUT)  # give pg a moment to spin up all the way
     engine = create_engine(
         'postgresql://snowshu:snowshu@snowshu_target:9999/snowshu')
     engine.execute(
@@ -55,7 +55,7 @@ def test_creates_replica(docker_flush):
                           name=TEST_NAME,
                           network='snowshu',
                           detach=True)
-    wait_for_spin_up(container_name=TEST_NAME)  # give pg a moment to spin up all the way
+    time.sleep(DOCKER_SPIN_UP_TIMEOUT)  # give pg a moment to spin up all the way
     engine = create_engine(
         f'postgresql://snowshu:snowshu@{TEST_NAME}:9999/snowshu')
     res = engine.execute(f'SELECT * FROM {TEST_TABLE}').fetchall()

--- a/tests/unit/test_configuration_parser.py
+++ b/tests/unit/test_configuration_parser.py
@@ -82,13 +82,13 @@ def test_loads_good_creds(stub_creds,stub_configs):
 def test_schema_verification_errors(stub_creds, stub_configs):
     stub_creds = stub_creds()
     stub_configs = stub_configs()
+    # create type error in replica.yml
     stub_creds['sources'][0]['password'] = True
 
     with tempfile.NamedTemporaryFile(mode='w') as mock_file:
         json.dump(stub_creds, mock_file)
         mock_file.seek(0)
         stub_configs['credpath']=mock_file.name
-        stub_configs['include_outliers']=10
         with pytest.raises(ValidationError) as exc:
             ConfigurationParser()._build_adapter_profile('source', stub_configs,
                             schema_path=Path("/app/snowshu/templates/credentials_schema.json"))

--- a/tests/unit/test_configuration_parser.py
+++ b/tests/unit/test_configuration_parser.py
@@ -5,6 +5,8 @@ import pytest
 from snowshu.configs import DEFAULT_MAX_NUMBER_OF_OUTLIERS
 from tests.common import rand_string
 from io import StringIO
+from pathlib import Path
+from jsonschema.exceptions import ValidationError
 import yaml
 from snowshu.core.configuration_parser import ConfigurationParser
 import os
@@ -12,7 +14,6 @@ from snowshu.samplings.samplings import DefaultSampling
 
 
 def test_fills_in_empty_source_values(stub_replica_configuration):
-
     for rel in stub_replica_configuration.specified_relations:
         assert isinstance(rel.unsampled, bool)
         assert isinstance(rel.relationships.bidirectional, list)
@@ -78,4 +79,23 @@ def test_loads_good_creds(stub_creds,stub_configs):
     assert adapter_profile.name == SOURCES_NAME
     assert adapter_profile.adapter.credentials.password == SOURCES_PASSWORD
 
+def test_schema_verification_errors(stub_creds, stub_configs):
+    stub_creds = stub_creds()
+    stub_configs = stub_configs()
+    stub_creds['sources'][0]['password'] = True
 
+    with tempfile.NamedTemporaryFile(mode='w') as mock_file:
+        json.dump(stub_creds, mock_file)
+        mock_file.seek(0)
+        stub_configs['credpath']=mock_file.name
+        stub_configs['include_outliers']=10
+        with pytest.raises(ValidationError) as exc:
+            ConfigurationParser()._build_adapter_profile('source', stub_configs,
+                            schema_path=Path("/app/snowshu/templates/credentials_schema.json"))
+    assert "True is not of type 'string'" in str(exc.value)
+
+    # config with missing credentials file
+    with pytest.raises(FileNotFoundError) as fnf_err:
+        mock_config_file = StringIO(yaml.dump(stub_configs))
+        ConfigurationParser().from_file_or_path(mock_config_file)
+    assert "Credentials specified in replica.yml not found" in fnf_err.value.strerror


### PR DESCRIPTION
This PR improves the error messages that might be encountered while loading config and credentials from replica.yml and credentials.yml. This is done using jsonschema validations.

What Changes?
- [x] validate input
- [x] Tone down logging (snowflake)
- [x] have time.sleep for docker spin up based on constant

