### PR TITLE
Target node in directional relation considered for catalog

### DIFF
--- a/snowshu/core/compile.py
+++ b/snowshu/core/compile.py
@@ -27,7 +27,7 @@ class RuntimeSourceCompiler:
             do_not_sample=False
             predicates=list()
             unions=list()
-            for child in [c for c in dag.successors(relation)]:
+            for child in dag.successors(relation):
                 for edge in dag.edges((relation,child),True):
                     edge_data=edge[2]
                     if edge_data['direction']=='bidirectional':
@@ -41,7 +41,7 @@ class RuntimeSourceCompiler:
                                                                                 edge_data['local_attribute'],
                                                                                 relation.max_number_of_outliers))
 
-            for parent in [p for p in dag.predecessors(relation)]:
+            for parent in dag.predecessors(relation):
                 for edge in dag.edges((parent,relation,),True):
                     edge_data=edge[2]
                     do_not_sample=edge_data['direction']=='bidirectional'

--- a/snowshu/core/graph.py
+++ b/snowshu/core/graph.py
@@ -4,7 +4,6 @@ from snowshu.core.models.relation import Relation
 from snowshu.core.configuration_parser import Configuration
 from typing import Tuple, Set, List
 from snowshu.logger import Logger
-from snowshu.core.samplings.utils import get_sampling_from_partial
 from snowshu.core.models.relation import at_least_one_full_pattern_match,\
     lookup_single_relation,\
     single_full_pattern_match
@@ -48,7 +47,7 @@ class SnowShuGraph:
         
         logger.info(f'Identified a total of {len(self.graph)} relations to sample based on the specified configurations.')
 
-        if not self.graph.is_directed():
+        if not networkx.algorithms.is_directed_acyclic_graph(self.graph):
             raise ValueError(
                 'The graph created by the specified trail path is not directed (circular reference detected).')
 
@@ -138,9 +137,6 @@ class SnowShuGraph:
                                    direction=edge['direction'],
                                    remote_attribute=edge['remote_attribute'],
                                    local_attribute=edge['local_attribute'])
-        if not graph.is_directed():
-            raise ValueError(
-                'The graph created by the specified trail path is not directed (circular reference detected).')
         return graph
 
     def get_graphs(self) -> tuple:

--- a/snowshu/core/graph.py
+++ b/snowshu/core/graph.py
@@ -17,7 +17,6 @@ class SnowShuGraph:
         self.dag: tuple = None
         self.graph: networkx.Graph = None
 
-    # TODO remove extra filtering of relations when building graph
     def build_graph(self, configs: Configuration) -> networkx.DiGraph:
         """Builds a directed graph per replica config.
         


### PR DESCRIPTION
Includes the relations from the second level (target) of the specified relations in replica.yml to create the catalog. 

Ref #43