### PR TITLE
Better error handling for check count and query

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,7 @@ psycopg2-binary==2.8.4
 scipy==1.4.1
 overrides==3.1.0
 jsonschema==3.2.0
+tenacity==7.0.0
 
 
 #SNOWFLAKE

--- a/snowshu/adapters/source_adapters/base_source_adapter.py
+++ b/snowshu/adapters/source_adapters/base_source_adapter.py
@@ -119,6 +119,8 @@ class BaseSourceAdapter(BaseSQLAdapter):
         """runs the query and closes the connection."""
         logger.debug('Beginning query execution...')
         start = time.time()
+        conn = None
+        cursor = None
         try:
             conn = self.get_connection()
             cursor = conn.connect()

--- a/snowshu/adapters/source_adapters/base_source_adapter.py
+++ b/snowshu/adapters/source_adapters/base_source_adapter.py
@@ -128,8 +128,10 @@ class BaseSourceAdapter(BaseSQLAdapter):
             logger.debug(f'Executed query in {time.time()-start} seconds.')
             frame = pd.read_sql_query(query_sql, conn)
         finally:
-            cursor.close()
-            conn.dispose()
+            if cursor:
+                cursor.close()
+            if conn:
+                conn.dispose()
         return frame
 
     def _correct_case(self,val:str)->str:

--- a/snowshu/core/graph_set_runner.py
+++ b/snowshu/core/graph_set_runner.py
@@ -47,17 +47,14 @@ class GraphSetRunner:
                                     target_adapter,
                                     analyze) for graph in graphs]
 
-        start_time = time.time()
-
         # Tables need to come first to prevent deps deadlocks with views
         for graphs in [table_graph_set, view_graph_set]:
             with ThreadPoolExecutor(max_workers=threads) as executor:
                 for executable in make_executables(graphs):
-                    executor.submit(self._traverse_and_execute,
-                                    executable, start_time)
+                    executor.submit(self._traverse_and_execute, executable)
 
-    def _traverse_and_execute(
-            self, executable: GraphExecutable, start_time: int) -> None:
+    def _traverse_and_execute(self, executable: GraphExecutable) -> None:
+        start_time = time.time()
         try:
             logger.debug(
                 f"Executing graph with {len(executable.graph)} relations in it...")

--- a/snowshu/logger.py
+++ b/snowshu/logger.py
@@ -51,6 +51,11 @@ class Logger:
     def remove_all_handlers(self, logger: logging.Logger) -> None:
         logger.handlers = list()
 
+    def log_retries(self, retry_state):
+        """ Function for passing to tenacity.retry decorator. """
+        self.logger.warning('Retrying %s: attempt %s ended with: %s',
+            retry_state.fn.__qualname__, retry_state.attempt_number, retry_state.outcome.exception())
+
     @property
     def logger(self) -> logging.Logger:
         return self._logger

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import tempfile
 import copy
 import json
 import yaml
+import re
 from snowshu.core.configuration_parser import ConfigurationParser
 from tests.conftest_modules.test_credentials import CREDENTIALS
 from tests.conftest_modules.test_configuration import CONFIGURATION
@@ -141,7 +142,7 @@ def sanitize_docker_environment():
     def is_snowshu_related_image(image)->bool:
         if len(image.tags) < 1:
             return False
-        return any([val in image.tags[0] for val in ('snowshu_replica_',
+        return any([re.search(val, image.tags[0]) for val in ('^snowshu_replica_\w+',
             'integration-test',
             'snowshu_target',)])
 

--- a/tests/unit/test_graph_runner.py
+++ b/tests/unit/test_graph_runner.py
@@ -29,7 +29,7 @@ def test_traverse_and_execute_analyze(stub_graph_set):
     dag_executable = GraphExecutable(dag, source_adapter, target_adapter, True)
 
     # longer dag
-    runner._traverse_and_execute(dag_executable, time())
+    runner._traverse_and_execute(dag_executable)
     for rel in dag.nodes:
         assert not isinstance(getattr(rel, 'data', None), pd.DataFrame)
         assert rel.source_extracted is True
@@ -47,7 +47,7 @@ def test_traverse_and_execute_analyze(stub_graph_set):
     iso_executable = GraphExecutable(iso, source_adapter, target_adapter, True)
     assert not isinstance(
         getattr(vals.iso_relation, 'data', None), pd.DataFrame)
-    runner._traverse_and_execute(iso_executable, time())
+    runner._traverse_and_execute(iso_executable)
     iso_relation = [node for node in iso.nodes][0]
     assert iso_relation.source_extracted is True
     assert iso_relation.target_loaded is False

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -1,4 +1,6 @@
+import pytest
 import mock
+from psycopg2 import OperationalError
 from snowshu.adapters.source_adapters.snowflake_adapter import SnowflakeAdapter
 from tests.common import rand_string, query_equalize
 from snowshu.core.models.relation import Relation
@@ -133,3 +135,16 @@ SELECT
 FROM 
     {relmock.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
 """)
+
+
+def test_retry_count_query():
+    """ Verifies that the retry decorator works as expected """
+    error_list = [OperationalError, OperationalError, OperationalError, SystemError, RuntimeError]
+    with mock.patch("snowshu.adapters.source_adapters.SnowflakeAdapter._count_query", side_effect=error_list):
+        sf = SnowflakeAdapter()
+        with pytest.raises(SystemError) as exc:
+            sf.check_count_and_query("select * from unknown_table", 10)
+        
+        # assert that the 4th error was raised
+        assert exc.errisinstance(SystemError)
+        assert sf.check_count_and_query.retry.statistics["attempt_number"] == 4


### PR DESCRIPTION
The `check_count_and_query` function had some UnboundErrors in its `finally` cleanup block, and in the case of an intermittent failure when querying the source, the entire replica would be built without the failed tables.

- [x] Fixed unbound variables
- [x] Added bounded retries to `check_count_and_query` 
- [x] Moved start time into `_traverse_and_execute` to fix misleading
- [x] Integration test clean has narrower criteria for image cleanup