### PR TITLE
Fixed coupling of config options to uuid emulation func

### DIFF
--- a/snowshu/adapters/target_adapters/postgres_adapter/functions/UUID_STRING.sql
+++ b/snowshu/adapters/target_adapters/postgres_adapter/functions/UUID_STRING.sql
@@ -1,4 +1,6 @@
 /* emulates snowflake's uuid_string() function for v4 UUIDs, v5 unsupported */
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
 CREATE OR REPLACE FUNCTION UUID_STRING()
 RETURNS TEXT AS
 $$

--- a/snowshu/templates/replica.yml
+++ b/snowshu/templates/replica.yml
@@ -8,7 +8,7 @@ target:
   adapter: 'postgres'
   adapter_args:
     pg_extensions:
-      - uuid-ossp
+      - citext
 source:
   profile: default
   sampling: default

--- a/tests/conftest_modules/test_configuration.py
+++ b/tests/conftest_modules/test_configuration.py
@@ -75,7 +75,7 @@ CONFIGURATION = {
     "target": {
         "adapter": "postgres",
         "adapter_args": {
-            "pg_extensions": ["uuid-ossp"]
+            "pg_extensions": ["citext"]
         }
     },
     "storage": {

--- a/tests/integration/snowflake/test_end_to_end.py
+++ b/tests/integration/snowflake/test_end_to_end.py
@@ -145,6 +145,12 @@ def test_applies_uuid_emulation_function(end_to_end):
     q = conn.execute(query)
     assert re.match('[0-9A-Fa-f-]{36}', q.fetchall()[0][0])
 
+def test_applies_pg_extensions(end_to_end):
+    conn = create_engine(SNOWSHU_DEVELOPMENT_STRING)
+    query = "SELECT CASE WHEN 'My_Cased_String'::citext = 'my_cased_string'::citext THEN 'SUCCESS' ELSE 'FAIL' END"
+    q = conn.execute(query)
+    assert q.fetchall()[0][0] == 'SUCCESS'
+
 def test_data_types(end_to_end):
     conn = create_engine(SNOWSHU_DEVELOPMENT_STRING)
     query = """


### PR DESCRIPTION
**Problem:**

Building a replica fails when the `pg_extensions` option does not include `uuid-ossp` since the `UUID_STRING()` definition for postgres requires it to be present.


**Solution:**

Add the `CREATE EXTENSION...`  statement to the `UUID_STRING()` SQL file definition so it is always loaded when `UUID_STRING` is loaded.

The references to `uuid-ossp` in the test configurations have been switched to `citext` to avoid collisions during integration tests between the `pg_extensions` option and the emulation functions that require extensions.

