### PR TITLE
Bumped requirement pins

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-pyyaml==5.3
-pandas==1.0.1
+pyyaml==5.4.1
+pandas==1.2.3
 docker==4.2.0
 click==7.0
 coloredlogs==14.0

--- a/requirements/snowflake_pins.txt
+++ b/requirements/snowflake_pins.txt
@@ -1,24 +1,25 @@
 ## because snowflake has loose pins on _everything_ the connectors break constantly. 
 ## this hard pins the requirements for snowflake-connector-python so we can manage them. 
 
-snowflake-sqlalchemy==1.2.1 # sqlalchemy & snowflake-connector-python are both weakly pinned here.
-sqlalchemy==1.3.13 
-snowflake-connector-python==2.2.1 
-azure-common==1.1.24
-azure-storage-blob==2.1.0
-boto3==1.11.17
-botocore==1.14.17
-docutils==0.15.2 # back-pin for botocore 
-requests==2.22.0
-urllib3==1.25.8
-certifi==2019.11.28
-pytz==2019.3
-pycryptodomex==3.9.6
+snowflake-sqlalchemy==1.2.4
+sqlalchemy==1.3.24
+snowflake-connector-python==2.4.2
+
+asn1crypto==1.4.0
+azure-common==1.1.27
+azure-storage-blob==12.8.0
+boto3==1.17.48
+botocore==1.20.48
+certifi==2020.12.5
+cffi==1.14.5
+chardet==3.0.4
+cryptography==3.4.7
+docutils==0.17
+idna==2.10
+oscrypto==1.2.1
+pycryptodomex==3.10.1
+pyjwt==2.0.1
 pyOpenSSL==19.1.0
-cffi==1.13.2
-cryptography==2.8
-ijson==2.6.1
-pyjwt==1.7.1
-idna==2.8
-oscrypto==1.2.0
-asn1crypto==1.3.0
+pytz==2021.1
+requests==2.25.1
+urllib3==1.26.4


### PR DESCRIPTION
This covers both dependabot PRs for `pyyaml` and `cryptography` packages as well as upgrading other necessary dependencies that were affected. 

The `snowflake` and `sqlalchemy` versions needed to be bumped as well (due to `cryptography` depedency), so all of the dependencies in `snowflake_pins` have been updated to the versions pulled when installing the `snowflake` and `sqlalchemy` packages. This should avoid unexpected breaks due to wide pins.

https://github.com/Health-Union/snowshu/pull/48
https://github.com/Health-Union/snowshu/pull/62