### PR TITLE
Unsampled relations aren't bound by the MAX_ALLOWED_ROWS check

### DIFF
--- a/snowshu/adapters/source_adapters/base_source_adapter.py
+++ b/snowshu/adapters/source_adapters/base_source_adapter.py
@@ -164,7 +164,7 @@ class BaseSourceAdapter(BaseSQLAdapter):
         """wraps any query in a COUNT statement, returns that integer."""
         raise NotImplementedError()
 
-    def check_count_and_query(self, query: str, max_count: int) -> pd.DataFrame:
+    def check_count_and_query(self, query: str, max_count: int, unsampled: bool) -> pd.DataFrame:
         """checks the count, if count passes returns results as a dataframe."""
         raise NotImplementedError()
 
@@ -181,7 +181,7 @@ class BaseSourceAdapter(BaseSQLAdapter):
         Returns:
             the raw value from cell [0][0]
         """
-        return self.check_count_and_query(query, 1).iloc[0][0]
+        return self.check_count_and_query(query, 1, False).iloc[0][0]
 
     def _get_data_type(self, source_type: str) -> DataType:
         try:

--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -357,13 +357,20 @@ LIMIT {max_number_of_outliers})
                     reraise=True)
     @overrides
     def check_count_and_query(self, query: str,
-                              max_count: int) -> pd.DataFrame:
+                              max_count: int,
+                              unsampled: bool) -> pd.DataFrame:
         """checks the count, if count passes returns results as a dataframe."""
         try:
             logger.debug('Checking count for query...')
             start_time = time.time()
             count = self._count_query(query)
-            assert count <= max_count
+            if unsampled and count > max_count:
+                warn_msg = (f'Unsampled relation has {count} rows which is over '
+                            f'the max allowed rows for this type of query ({max_count}). '
+                            f'All records will be loaded into replica.')
+                logger.warning(warn_msg)
+            else:
+                assert count <= max_count
             logger.debug(
                 f'Query count safe at {count} rows in {time.time()-start_time} seconds.')
         except AssertionError:

--- a/snowshu/core/graph_set_runner.py
+++ b/snowshu/core/graph_set_runner.py
@@ -86,7 +86,8 @@ class GraphSetRunner:
                             f'Relation {relation.dot_notation} is a view, skipping.')
                     else:
                         result = executable.source_adapter.check_count_and_query(relation.compiled_query,
-                                                                                 MAX_ALLOWED_ROWS).iloc[0]
+                                                                                 MAX_ALLOWED_ROWS,
+                                                                                 relation.unsampled).iloc[0]
                         relation.population_size = result.population_size
                         relation.sample_size = result.sample_size
                         logger.info(
@@ -115,7 +116,7 @@ class GraphSetRunner:
                             f'Retrieving records from source {relation.dot_notation}...')
                         try:
                             relation.data = executable.source_adapter.check_count_and_query(
-                                relation.compiled_query, MAX_ALLOWED_ROWS)
+                                relation.compiled_query, MAX_ALLOWED_ROWS, relation.unsampled)
                         except Exception as exc:
                             raise SystemError(
                                 f'Failed execution of extraction sql statement: {relation.compiled_query} {exc}')

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -144,7 +144,7 @@ def test_retry_count_query():
     with mock.patch("snowshu.adapters.source_adapters.SnowflakeAdapter._count_query", side_effect=error_list):
         sf = SnowflakeAdapter()
         with pytest.raises(SystemError) as exc:
-            sf.check_count_and_query("select * from unknown_table", 10)
+            sf.check_count_and_query("select * from unknown_table", 10, False)
         
         # assert that the 4th error was raised
         assert exc.errisinstance(SystemError)


### PR DESCRIPTION
*Problem*: If an unsampled relation had more than the MAX_ALLOWED_ROWS value, errors would be raised during creation of the replica.

*Fix*: Exempt unsampled relations from the MAX_ALLOWED_ROWS cap. A warning it logged in those cases where the row count exceeds that value.
