### PR TITLE
Install extra postgres os packages

### DIFF
--- a/snowshu/adapters/target_adapters/base_target_adapter.py
+++ b/snowshu/adapters/target_adapters/base_target_adapter.py
@@ -140,7 +140,7 @@ AS
             self.DOCKER_IMAGE,
             self.DOCKER_START_COMMAND,
             self.DOCKER_TARGET_PORT,
-            self.CLASSNAME,
+            self,
             source_adapter_name,
             self._build_snowshu_envars(
                 self.DOCKER_SNOWSHU_ENVARS))

--- a/snowshu/adapters/target_adapters/postgres_adapter/postgres_adapter.py
+++ b/snowshu/adapters/target_adapters/postgres_adapter/postgres_adapter.py
@@ -17,6 +17,7 @@ class PostgresAdapter(BaseTargetAdapter):
     name = 'postgres'
     dialect = 'postgres'
     DOCKER_IMAGE = 'postgres:12'
+    PRELOADED_PACKAGES = ['postgresql-plpython3-12']
     MATERIALIZATION_MAPPINGS = dict(TABLE=mz.TABLE, VIEW=mz.VIEW)
     DOCKER_REMOUNT_DIRECTORY = DOCKER_REMOUNT_DIRECTORY
 
@@ -85,11 +86,10 @@ class PostgresAdapter(BaseTargetAdapter):
         commands.append(f'cp -a /var/lib/postgresql/data/* /{DOCKER_REMOUNT_DIRECTORY}')
         return commands
 
-    @staticmethod
-    def image_initialize_bash_commands() -> List[str]:
+    def image_initialize_bash_commands(self) -> List[str]:
         commands = list()
         # install extra postgres extension packages here
-        commands.append('apt-get update && apt-get install -y postgresql-plpython3-12')
+        commands.append(f'apt-get update && apt-get install -y {" ".join(self.PRELOADED_PACKAGES)}')
         return commands
 
     @staticmethod

--- a/snowshu/adapters/target_adapters/postgres_adapter/postgres_adapter.py
+++ b/snowshu/adapters/target_adapters/postgres_adapter/postgres_adapter.py
@@ -86,6 +86,13 @@ class PostgresAdapter(BaseTargetAdapter):
         return commands
 
     @staticmethod
+    def image_initialize_bash_commands() -> List[str]:
+        commands = list()
+        # install extra postgres extension packages here
+        commands.append('apt-get update && apt-get install -y postgresql-plpython3-12')
+        return commands
+
+    @staticmethod
     def docker_commit_changes() -> str:
         """To finalize the image we need to set envars for the container."""
         return f"ENV PGDATA /{DOCKER_REMOUNT_DIRECTORY}"

--- a/snowshu/templates/replica.yml
+++ b/snowshu/templates/replica.yml
@@ -19,7 +19,7 @@ source:
       schemas:
       - pattern: "(?i)(EXTERNAL_DATA|SOURCE_SYSTEM|TESTS_DATA)" # matches our test schemas
         relations:
-        - '^(?i).*(?<!_view)$' # matches all relations that do not end with '_VIEW'
+        - '(?i)^.*(?<!_view)$' # matches all relations that do not end with '_VIEW'
   # these are exceptions to the 'default' sampling above
   specified_relations: 
   - database: SNOWSHU_DEVELOPMENT

--- a/tests/integration/test_docker_end_to_end.py
+++ b/tests/integration/test_docker_end_to_end.py
@@ -28,7 +28,7 @@ def test_creates_replica(docker_flush):
         target_adapter.DOCKER_IMAGE,
         target_adapter.DOCKER_START_COMMAND,
         9999,
-        target_adapter.CLASSNAME,
+        target_adapter,
         'SnowflakeAdapter',
         ['POSTGRES_USER=snowshu',
          'POSTGRES_PASSWORD=snowshu',
@@ -64,4 +64,6 @@ def test_creates_replica(docker_flush):
     assert ('a', 1,) in res
     assert ('b', 2,) in res
     assert ('c', 3,) in res
+    # verify that the extra OS packages are installed
+    res = engine.execute("create extension plpython3udf;")
     shdocker.remove_container(TEST_NAME)

--- a/tests/integration/test_docker_end_to_end.py
+++ b/tests/integration/test_docker_end_to_end.py
@@ -65,5 +65,5 @@ def test_creates_replica(docker_flush):
     assert ('b', 2,) in res
     assert ('c', 3,) in res
     # verify that the extra OS packages are installed
-    res = engine.execute("create extension plpython3udf;")
+    res = engine.execute("create extension plpython3u;")
     shdocker.remove_container(TEST_NAME)

--- a/tests/unit/test_base_adapter.py
+++ b/tests/unit/test_base_adapter.py
@@ -15,7 +15,7 @@ def rand_creds(args) -> Credentials:
     return Credentials(**kwargs)
 
 
-class TestAdapter(BaseSQLAdapter):
+class StubbedAdapter(BaseSQLAdapter):
 
     REQUIRED_CREDENTIALS = (USER, PASSWORD, HOST)
     ALLOWED_CREDENTIALS = (ACCOUNT, SCHEMA)
@@ -25,7 +25,7 @@ class TestAdapter(BaseSQLAdapter):
 
 def test_sets_credentials():
 
-    base = TestAdapter()
+    base = StubbedAdapter()
 
     with pytest.raises(KeyError):
         base.credentials = rand_creds((HOST,))
@@ -39,7 +39,7 @@ def test_sets_credentials():
 
 
 def test_default_conn_string():
-    base = TestAdapter()
+    base = StubbedAdapter()
     base.dialect = 'postgres'
 
     base.REQUIRED_CREDENTIALS = (USER, PASSWORD, DATABASE, HOST)
@@ -56,7 +56,7 @@ def test_build_catalog():
     config_patterns = [
         dict(database="snowshu_development",
              schema=".*",
-             name="^(?i).*(?<!_view)$"),
+             name="(?i)^.*(?<!_view)$"),
         dict(database="snowshu_development",
              schema="source_system",
              name="order_items_view")


### PR DESCRIPTION
*Problem*: The default postgres docker image doesn't come with any of the pl-language OS packages installed. Adding them to the image requires users to create the replica, run it, install packages, and commit the container to an image.

*Solution*: Snowshu can install OS packages (currently only `plpython3`) before the replica is created and stored as an image.

The packages that are installed are defined in the target adapter since they are dependent upon the version of the postgres image which isn't currently exposed to the user. They can be exposed in the future if necessary.