### PR TITLE
Postgres sanitize 0x00

### DIFF
--- a/snowshu/adapters/target_adapters/base_target_adapter.py
+++ b/snowshu/adapters/target_adapters/base_target_adapter.py
@@ -120,7 +120,7 @@ AS
                                  chunksize=DEFAULT_INSERT_CHUNK_SIZE,
                                  method='multi')
         except Exception as exc:
-            logger.info("Failed to load data into %s:%s", relation.quoted_dot_notation, exc)
+            logger.info("Exception encountered loading data into %s:%s", relation.quoted_dot_notation, exc)
             raise exc
         logger.info('Data loaded into relation %s', relation.quoted_dot_notation)
 

--- a/tests/unit/test_postgres_target_adapter.py
+++ b/tests/unit/test_postgres_target_adapter.py
@@ -1,0 +1,37 @@
+from snowshu.core.models import data_types
+from pandas.core.frame import DataFrame
+from snowshu.core.models.attribute import Attribute
+from snowshu.core.models.materializations import TABLE
+from snowshu.adapters.target_adapters.postgres_adapter import PostgresAdapter
+from snowshu.core.models.relation import Relation
+
+
+def test_x00_replacement():
+    adapter = PostgresAdapter()
+    id_col = "id"
+    content_col = "content"
+    normal_val = "normal_value"
+    weird_value = "weird\x00value"
+    custom_replacement = "__CUSTOM_VALUE__"
+
+    cols = [
+        Attribute(id_col, data_types.BIGINT),
+        Attribute(content_col, data_types.VARCHAR)
+    ]
+    # test default replacement
+    relation = Relation("db", "schema", "relation", TABLE, cols)
+    relation.data = DataFrame({id_col:[1,2],content_col: [normal_val, weird_value]})
+
+    fixed_relation = adapter.replace_x00_values(relation)
+    assert all(fixed_relation.data.loc[fixed_relation.data[id_col] == 1, [content_col]] == normal_val)
+    assert all(fixed_relation.data.loc[fixed_relation.data[id_col] == 2, [content_col]] == "weirdvalue")
+
+    # test custom replacement
+    adapter = PostgresAdapter(pg_0x00_replacement=custom_replacement)
+    relation = Relation("db", "schema", "relation", TABLE, cols)
+    relation.data = DataFrame({id_col:[1,2],content_col: [normal_val, weird_value]})
+
+    fixed_relation = adapter.replace_x00_values(relation)
+    assert all(fixed_relation.data.loc[fixed_relation.data[id_col] == 1, [content_col]] == normal_val)
+    assert all(fixed_relation.data.loc[fixed_relation.data[id_col] == 2, [content_col]] == f"weird{custom_replacement}value")
+


### PR DESCRIPTION
*Problem*: Snowflake allows characters with unicode value 0 in their varchar type, but postgres does not. Any records with that character fail to load into a postgres snowshu replica.

*Solution*: Sanitize the affected columns to remove the invalid character.

In the case that the initial relation load fails with that specific error, the data is searched for the invalid character, replaced with the empty string (configurable via `adapter_args`), and another load is attempted. Warnings are logged during this process to inform the user of the changes.