### PR TITLE
More in code documentation

### DIFF
--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -202,6 +202,7 @@ FROM
                                    subject_key: str,
                                    constraint_key: str,
                                    max_number_of_outliers: int) -> str:
+        """ Union statements to select outliers. This does not pull in NULL values. """
         return f"""
 (SELECT
     *

--- a/snowshu/core/compile.py
+++ b/snowshu/core/compile.py
@@ -17,8 +17,17 @@ class RuntimeSourceCompiler:
                                      dag: networkx.Graph,
                                      source_adapter: Type[BaseSourceAdapter],
                                      analyze: bool) -> Relation:
-        """generates and populates the compiled sql for each relation in a
-        dag."""
+        """ Generates the sql statements for the given relation
+
+            Args:
+                relation (Relation): the relation to generate the sql for
+                dag (Graph): the connected dependency graph that contains the relation
+                source_adapter (BaseSourceAdapter): the source adapter for the sql dialect
+                analyze (bool): whether to generate sql statements for analyze or actaul sampling
+
+            Returns:
+                Relation: the given relation with `compiled_query` populated
+        """
         query = str()
         if relation.is_view:
             relation.core_query, relation.compiled_query = [

--- a/snowshu/core/graph_set_runner.py
+++ b/snowshu/core/graph_set_runner.py
@@ -87,8 +87,8 @@ class GraphSetRunner:
         """
         start_time = time.time()
         if self.barf:
-            with open(os.path.join(self.barf_output, f'{[n for n in executable.graph.nodes][0].name}.component'), 'wb') as barf_file:
-                nx.write_multiline_adjlist(executable.graph, barf_file)
+            with open(os.path.join(self.barf_output, f'{[n for n in executable.graph.nodes][0].name}.component'), 'wb') as cmp_file:  # noqa pylint: disable=unnecessary-comprehension
+                nx.write_multiline_adjlist(executable.graph, cmp_file)
         try:
             logger.debug(
                 f"Executing graph with {len(executable.graph)} relations in it...")

--- a/snowshu/core/replica/replica_factory.py
+++ b/snowshu/core/replica/replica_factory.py
@@ -42,6 +42,7 @@ class ReplicaFactory:
         if len(graphs) < 1:
             return "No relations found per provided replica configuration, exiting."
 
+        # TODO replica container should not be started for analyze commands
         self.config.target_profile.adapter.initialize_replica(
             self.config.source_profile.name)
         runner = GraphSetRunner()


### PR DESCRIPTION
This adds more documentation mostly to the graph related functions (e.g. building and traversal).

Extra barf output has also been added. Each component of the configuration's graph is dumped to a file in addition to the sql file output for the `--barf` flag.