### PR TITLE
Fix correct case utility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   snowshu:
-    image: snowshu
+    image: snowshu-dev
     build:
       context: .
       dockerfile: Dockerfile

--- a/snowshu/core/utils.py
+++ b/snowshu/core/utils.py
@@ -18,8 +18,20 @@ logger = Logger().logger
 
 
 def correct_case(val: str, upper: bool = True):
+    """ Returns the case corrected value based on general sql identifier rules
+
+        If the value is entirely one case, made up of only word characters
+        and doesn't begin with a number, we can conform the case
+
+        ARGS:
+            - val: string that is the value to correct case for
+            - upper: flag to determine the case to conform to. Defaults to True (uppercase)
+        RETURNS:
+            the case corrected value
+    """
     if any({val.isupper(), val.islower()}) and \
-       re.fullmatch(r'^(\w|\s)*$', val):
+            re.fullmatch(r'^\w*$', val) and \
+            not re.fullmatch(r'^[0-9].*', val):
         val = val.upper() if upper else val.lower()
     return val
 

--- a/tests/assets/data/data_types_snowflake_creation.sql
+++ b/tests/assets/data/data_types_snowflake_creation.sql
@@ -111,7 +111,10 @@ CREATE TABLE IF NOT EXISTS "SNOWSHU_DEVELOPMENT"."TESTS_DATA"."CASE_TESTING" (
     lower_col VARCHAR,
     CamelCasedCol VARCHAR,
     Snake_Case_Camel_Col VARCHAR,
-    "Spaces Col" VARCHAR
+    "Spaces Col" VARCHAR,
+    "UNIFORM SPACE" VARCHAR,
+    "uniform lower" VARCHAR,
+    "1" VARCHAR
 );
 
 
@@ -121,6 +124,9 @@ INSERT INTO "SNOWSHU_DEVELOPMENT"."TESTS_DATA"."CASE_TESTING" (
     lower_col,
     CamelCasedCol,
     Snake_Case_Camel_Col,
-    "Spaces Col"
+    "Spaces Col",
+    "UNIFORM SPACE",
+    "uniform lower",
+    "1"
 )
-VALUES('a', 'b', 'c', 'd', 'e', 'f');
+VALUES('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i');

--- a/tests/integration/snowflake/test_end_to_end.py
+++ b/tests/integration/snowflake/test_end_to_end.py
@@ -210,3 +210,33 @@ AND
 "variant_col":"json"
 }
     assert {t[0]:t[1] for t in type_mappings} == EXPECTED_DATA_TYPES
+
+
+def test_casing(end_to_end):
+    conn = create_engine(SNOWSHU_DEVELOPMENT_STRING)
+    query = """
+        SELECT 
+            COLUMN_NAME,
+            DATA_TYPE
+        FROM 
+            SNOWSHU_DEVELOPMENT.information_schema.columns 
+        WHERE 
+            TABLE_SCHEMA = 'tests_data' 
+        AND 
+            TABLE_NAME='case_testing'
+    """
+
+    q = conn.execute(query)
+    type_mappings = q.fetchall()
+    EXPECTED_DATA_TYPES={
+        "lower_col":"character varying",
+        "upper_col":"character varying",  # fully upper-case should map to all lower (snowflake -> postgres)
+        "CamelCasedCol":"character varying",
+        "quoted_upper_col":"character varying",  # fully upper-case should map to all lower (snowflake -> postgres)
+        "1":"character varying",
+        "Spaces Col":"character varying",
+        "UNIFORM SPACE":"character varying",
+        "uniform lower":"character varying",
+        "Snake_Case_Camel_Col":"character varying",
+    }
+    assert {t[0]:t[1] for t in type_mappings} == EXPECTED_DATA_TYPES

--- a/tests/unit/test_core_utils.py
+++ b/tests/unit/test_core_utils.py
@@ -11,17 +11,18 @@ def test_case_insensitive_search():
 
 def test_correct_case():
 
-    correct=['upper','LOWER','SNAKE_CASED','lower_snake']
-    leave=['Upper','lOWER','Space Cased','^regex$','Other_snake']
+    correct = ['upper','LOWER','SNAKE_CASED','lower_snake','_UNDERSCORE_START','_lower_underscore_start']
+    leave = ['Upper','lOWER','Space Cased','^regex$','Other_snake','UNIFORM SPACE CASED','uniform lower space',\
+             '0248_num_start','0248_NUM_START','0248','0','$dollar_start']
 
     def correct_test_suite(under_test,upper):
         for item in under_test:
             expected = item.upper() if upper else item.lower()
-            assert correct_case(item,upper)== expected
+            assert correct_case(item,upper) == expected
 
     def leave_test_suite(under_test,upper):
         for item in under_test:
-            correct_case(item,upper)== item
+            assert correct_case(item,upper) == item
 
     [correct_test_suite(correct,x) for x in (True,False,)]
     [leave_test_suite(leave,x) for x in (True,False,)]


### PR DESCRIPTION
This PR fixes the changing case of columns with names like `UNIFORM SPACE CASE` and adds tests to verify that. It also addresses the case when the columns start with a number.

**Original Behavior**
When a source DB has the column identifier `UNIFORMLY SPACED COLUMN`, it was mapped to `uniformly spaced column` if the case changed between target and source.

**New Behavior**
When a source DB has the column identifier `UNIFORMLY SPACED COLUMN`, it needs to be preserved since any reference to that column will need to be quoted to handle the spaces.