### PR TITLE
Support regex in remote relationships

### DIFF
--- a/snowshu/core/graph.py
+++ b/snowshu/core/graph.py
@@ -168,7 +168,7 @@ class SnowShuGraph:
                             relationship[attr] = getattr(downstream_partition[0], attr)
 
                         graph = SnowShuGraph._process_downstream_relation_set(relationship,
-                                                                              downstream_relations,
+                                                                              downstream_partition,
                                                                               graph,
                                                                               available_nodes)
                 # no wildcards present in relationship definition

--- a/snowshu/core/graph.py
+++ b/snowshu/core/graph.py
@@ -4,8 +4,6 @@ import networkx
 
 from snowshu.core.configuration_parser import Configuration
 from snowshu.core.models.relation import (Relation,
-                                          at_least_one_full_pattern_match,
-                                          lookup_single_relation,
                                           single_full_pattern_match)
 from snowshu.exceptions import InvalidRelationshipException
 from snowshu.logger import Logger
@@ -115,14 +113,13 @@ class SnowShuGraph:
                             x,
                             relation_pattern_dict),     # noqa pylint: disable=cell-var-from-loop
                         available_nodes))
-                for rel in unsampled_relations:
-                    rel.unsampled = True
-                    graph.add_node(rel)
+                for uns_rel in unsampled_relations:
+                    uns_rel.unsampled = True
+                    graph.add_node(uns_rel)
                 continue
 
             # processing for non-unsampled relations
             # create a list of the relationship remote patterns and attributes
-            # ( innappropriately called edges )
             relationship_dicts = list()
             for relationship_type in ('bidirectional', 'directional',):
                 relationship_dicts += [
@@ -130,51 +127,146 @@ class SnowShuGraph:
                         direction=relationship_type,
                         database=val.database_pattern,
                         schema=val.schema_pattern,
-                        relation=val.relation_pattern,
+                        name=val.relation_pattern,
                         remote_attribute=val.remote_attribute,
-                        local_attribute=val.local_attribute) for val in relation.relationships.__dict__[relationship_type]]
+                        local_attribute=val.local_attribute
+                    ) for val in relation.relationships.__dict__[relationship_type]]
 
-            # for each relationship, find upstream and downstream relations, then create the appropriate edges
+            # for each relationship, find up/downstream relations, then create the appropriate edges
             for relationship in relationship_dicts:
                 # determine downstream relations from relation patterns
                 downstream_relations = set(
                     filter(
-                        lambda x: single_full_pattern_match(
-                            x,
-                            relation_pattern_dict),     # noqa  pylint: disable=cell-var-from-loop
-                        available_nodes))
-                for rel in downstream_relations:
-                    # populate any string wildcard upstreams
-                    for attr in ('database', 'schema',):
-                        relationship[attr] = relationship[attr] if relationship[attr] is not None else getattr(
-                            rel, attr)
-                    # TODO in the case of regex in the remote relation, this needs to handle multiple upstream relations per downstream_relation
-                    # in the case that there is a many-many relationship between upstream_relations and downstream_relations abort and warn user
-                    upstream_relation = lookup_single_relation(
-                        relationship, available_nodes)
+                        lambda x: single_full_pattern_match(x, relation_pattern_dict),  # noqa  pylint: disable=cell-var-from-loop
+                        available_nodes
+                    )
+                )
+                if not downstream_relations:
+                    raise InvalidRelationshipException(
+                        f'Relationship {relationship} was specified, but '
+                        f'{relation_pattern_dict} does not match any relations '
+                        f'Please verify replica configuration.'
+                    )
+
+                # check for wild cards
+                possible_wildcard_attrs = ('database', 'schema',)
+                wildcard_attrs = [attr for attr in possible_wildcard_attrs if relationship[attr] is None]
+
+                # TODO DRY out the logic branches here
+                # if there are wildcard attributes, partition downstream relations
+                if wildcard_attrs:
+                    wildcard_partitions = {}
+                    for down_rel in downstream_relations:
+                        # create wildcard key off of (in case there are multiple wildcards)
+                        wildcard_key = '|'.join([getattr(down_rel, attr) for attr in wildcard_attrs])
+                        val = wildcard_partitions.get(wildcard_key, [])
+                        val.append(down_rel)
+                        wildcard_partitions[wildcard_key] = val
+
+                    for _, downstream_partition in wildcard_partitions.items():
+                        # populate any wildcard patterns with the appropriate values from first element
+                        for attr in wildcard_attrs:
+                            relationship[attr] = getattr(downstream_partition[0], attr)
+
+                        # find any of the upstream relations
+                        upstream_relations = set(
+                            filter(
+                                lambda x: single_full_pattern_match(x, relationship),  # noqa pylint: disable=cell-var-from-loop
+                                available_nodes)
+                        )
+                        # determine the set difference for verification
+                        downstream_partition_set = set(downstream_partition)
+                        upstream_without_downstream = upstream_relations.difference(downstream_partition_set)
+
+                        # check to make sure an upstream relation was found
+                        if not upstream_without_downstream:
+                            raise InvalidRelationshipException(
+                                f'It looks like the wildcard relation '
+                                f'{relationship["database"]}.{relationship["schema"]}.{relationship["name"]} '
+                                f'was specified as a dependency, but it does not exist.')
+                        # check to see if there was an intersection between the upstream and downstream relations
+                        if len(upstream_without_downstream) != len(upstream_relations):
+                            logger.warning(
+                                f'Relationship {relationship} defines at least one downstream '
+                                f'relation in the upstream relation set. Ignoring the occurrence '
+                                f'in the upstream set. Please verify replica config file.'
+                            )
+                        # check to make sure we aren't trying to generate a many-to-many relationship
+                        if len(upstream_without_downstream) > 1 and len(downstream_partition_set) > 1:
+                            raise InvalidRelationshipException(
+                                f'Relationship {relationship} defines a many-to-many '
+                                f'relationship between tables in the source location. '
+                                f'Many-to-many relationship are not allowed by SnowShu '
+                                f'as they are usually unintended side effects of lenient regex.'
+                            )
+                        # check to make sure found upstream relation is not a view
+                        view_relations = [r.quoted_dot_notation for r in upstream_relations if r.is_view]
+                        if view_relations:
+                            raise InvalidRelationshipException(
+                                f'Relations {view_relations} are views, '
+                                f'but have been specified as an upstream dependency for '
+                                f'relation {relation.quoted_dot_notation}. '
+                                f'View dependencies are not allowed by SnowShu.'
+                            )
+
+                        for downstream_relation in downstream_partition_set:
+                            for upstream_relation in upstream_without_downstream:
+                                graph.add_edge(upstream_relation,
+                                               downstream_relation,
+                                               direction=relationship['direction'],
+                                               remote_attribute=relationship['remote_attribute'],
+                                               local_attribute=relationship['local_attribute'])
+                # no wildcards present in relationship definition
+                else:
+                    # find any of the upstream relations
+                    upstream_relations = set(
+                        filter(
+                            lambda x: single_full_pattern_match(x, relationship),  # noqa pylint: disable=cell-var-from-loop
+                            available_nodes
+                        )
+                    )
+                    # determine the set difference for verification
+                    upstream_without_downstream = upstream_relations.difference(downstream_relations)
+
                     # check to make sure an upstream relation was found
-                    if upstream_relation is None:
-                        raise ValueError(
-                            f'It looks like the wildcard relation '
-                            f'{relationship["database"]}.{relationship["schema"]}.{relationship["relation"]} '
-                            f'was specified as a dependency, but it does not exist.')
-                    # check to make sure found upstream relation is not a view
-                    if upstream_relation.is_view:
+                    if not upstream_without_downstream:
                         raise InvalidRelationshipException(
-                            f'Relation {upstream_relation.quoted_dot_notation} is a view, '
-                            f'but has been specified as an upstream dependency for '
+                            f'It looks like the relation '
+                            f'{relationship["database"]}.{relationship["schema"]}.{relationship["name"]} '
+                            f'was specified as a dependency, but it does not exist.')
+                    # check to see if there was an intersection between the upstream and downstream relations
+                    if len(upstream_without_downstream) != len(upstream_relations):
+                        logger.warning(
+                            f'Relationship {relationship} defines at least one downstream '
+                            f'relation in the upstream relation set. Ignoring the occurrence '
+                            f'in the upstream set. Please verify replica config file.'
+                        )
+                    # check to make sure we aren't trying to generate a many-to-many relationship
+                    if len(upstream_without_downstream) > 1 and len(downstream_relations) > 1:
+                        raise InvalidRelationshipException(
+                            f'Relationship {relationship} defines a many-to-many '
+                            f'relationship between tables in the source location. '
+                            f'Many-to-many relationship are not allowed by SnowShu '
+                            f'as they are usually unintended side effects of lenient regex.'
+                        )
+                    # check to make sure found upstream relation is not a view
+                    view_relations = [r.quoted_dot_notation for r in upstream_relations if r.is_view]
+                    if view_relations:
+                        raise InvalidRelationshipException(
+                            f'Relations {view_relations} are views, '
+                            f'but have been specified as an upstream dependency for '
                             f'relation {relation.quoted_dot_notation}. '
-                            f'View dependencies are not allowed by SnowShu.')
-                    # in the case of a non-empty intersection between downstream and upstream relations
-                    # for 1-many or many-1 situations, throw warning and ignore
-                    # for 1-1, throw error since no edge would be created (original case)
-                    if upstream_relation == rel:
-                        continue
-                    graph.add_edge(upstream_relation,
-                                   rel,
-                                   direction=relationship['direction'],
-                                   remote_attribute=relationship['remote_attribute'],
-                                   local_attribute=relationship['local_attribute'])
+                            f'View dependencies are not allowed by SnowShu.'
+                        )
+
+                    for downstream_relation in downstream_relations:
+                        for upstream_relation in upstream_without_downstream:
+                            graph.add_edge(upstream_relation,
+                                           downstream_relation,
+                                           direction=relationship['direction'],
+                                           remote_attribute=relationship['remote_attribute'],
+                                           local_attribute=relationship['local_attribute'])
+
         return graph
 
     def get_graphs(self) -> tuple:

--- a/snowshu/core/graph.py
+++ b/snowshu/core/graph.py
@@ -34,21 +34,18 @@ class SnowShuGraph:
         """
         logger.debug('Building graph from config...')
 
-        full_catalog = configs.source_profile.adapter.build_catalog(
+        catalog = configs.source_profile.adapter.build_catalog(
             patterns=self._build_sum_patterns_from_configs(configs),
             thread_workers=configs.threads)
         # set defaults for all relations in the catalog
-        for relation in full_catalog:
+        for relation in catalog:
             self._set_globals_for_node(relation, configs)
             self._set_overriding_params_for_node(relation, configs)
 
-        included_relations = self._filter_relations(
-            full_catalog, self._build_sum_patterns_from_configs(configs))
-
         # build graph and add edges
         graph = networkx.DiGraph()
-        graph.add_nodes_from(included_relations)
-        self.graph = self._apply_specifications(configs, graph, full_catalog)
+        graph.add_nodes_from(catalog)
+        self.graph = self._apply_specifications(configs, graph, catalog)
 
         logger.info(
             f'Identified a total of {len(self.graph)} relations to sample based on the specified configurations.')
@@ -243,15 +240,6 @@ class SnowShuGraph:
             approved_specified_patterns + approved_second_level_specified_patterns
         logger.debug(f'All config primary patterns: {all_patterns}')
         return all_patterns
-
-    @staticmethod
-    def _filter_relations(full_catalog: iter,
-                          patterns: dict) -> Set[Relation]:
-        """applies patterns to the full catalog to build the filtered relation
-        set."""
-
-        return set(filter(lambda rel: at_least_one_full_pattern_match(rel, patterns),
-                          full_catalog))
 
     @staticmethod
     def _set_globals_for_node(relation: Relation, configs: Configuration) -> Relation:

--- a/snowshu/core/graph.py
+++ b/snowshu/core/graph.py
@@ -144,7 +144,7 @@ class SnowShuGraph:
                 if not downstream_relations:
                     raise InvalidRelationshipException(
                         f'Relationship {relationship} was specified, but '
-                        f'{relation_pattern_dict} does not match any relations '
+                        f'{relation_pattern_dict} does not match any relations. '
                         f'Please verify replica configuration.'
                     )
 
@@ -152,7 +152,7 @@ class SnowShuGraph:
                 possible_wildcard_attrs = ('database', 'schema',)
                 wildcard_attrs = [attr for attr in possible_wildcard_attrs if relationship[attr] is None]
 
-                # TODO DRY out the logic branches here
+                # TODO DRY out the logic branches here - from upstream_relations downwards should be the same logic
                 # if there are wildcard attributes, partition downstream relations
                 if wildcard_attrs:
                     wildcard_partitions = {}
@@ -205,7 +205,7 @@ class SnowShuGraph:
                             raise InvalidRelationshipException(
                                 f'Relations {view_relations} are views, '
                                 f'but have been specified as an upstream dependency for '
-                                f'relation {relation.quoted_dot_notation}. '
+                                f'relation {relation}. '
                                 f'View dependencies are not allowed by SnowShu.'
                             )
 
@@ -255,7 +255,7 @@ class SnowShuGraph:
                         raise InvalidRelationshipException(
                             f'Relations {view_relations} are views, '
                             f'but have been specified as an upstream dependency for '
-                            f'relation {relation.quoted_dot_notation}. '
+                            f'relation {relation}. '
                             f'View dependencies are not allowed by SnowShu.'
                         )
 

--- a/snowshu/core/graph_set_runner.py
+++ b/snowshu/core/graph_set_runner.py
@@ -87,7 +87,7 @@ class GraphSetRunner:
         """
         start_time = time.time()
         if self.barf:
-            with open(os.path.join(self.barf_output, f'{[n for n in executable.graph.nodes][0].name}.component'), 'wb') as cmp_file:  # noqa pylint: disable=unnecessary-comprehension
+            with open(os.path.join(self.barf_output, f'{[n for n in executable.graph.nodes][0].dot_notation}.component'), 'wb') as cmp_file:  # noqa pylint: disable=unnecessary-comprehension
                 nx.write_multiline_adjlist(executable.graph, cmp_file)
         try:
             logger.debug(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from snowshu.core.configuration_parser import ConfigurationParser
 from snowshu.core.models import Attribute, Relation
 from tests.common import rand_string
 from tests.conftest_modules.mock_docker_images import MockImageFactory
-from tests.conftest_modules.test_configuration import CONFIGURATION
+from tests.conftest_modules.test_configuration import CONFIGURATION, BASIC_CONFIGURATION
 from tests.conftest_modules.test_credentials import CREDENTIALS
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,24 @@ class RelationTestHelper:
             name='birelation_right', **self.rand_relation_helper())
         self.view_relation = Relation(
             name='view_relation', **self.rand_relation_helper())
+
+        self.downstream_wildcard_relation_1 = Relation(
+            name='downstream_wildcard_relation_1', **self.rand_relation_helper())
+        self.downstream_wildcard_relation_2 = Relation(
+            name='downstream_wildcard_relation_2', **self.rand_relation_helper())
+        self.upstream_wildcard_relation_1 = Relation(
+            name='upstream_wildcard_relation_1',
+            schema=self.downstream_wildcard_relation_1.schema,
+            database=self.downstream_wildcard_relation_1.database,
+            materialization=mz.TABLE,
+            attributes=[])
+        self.upstream_wildcard_relation_2 = Relation(
+            name='upstream_wildcard_relation_2',
+            schema=self.downstream_wildcard_relation_2.schema,
+            database=self.downstream_wildcard_relation_2.database,
+            materialization=mz.TABLE,
+            attributes=[])
+
         self.bidirectional_key_left = rand_string(10),
         self.bidirectional_key_right = rand_string(8),
         self.directional_key = rand_string(15)
@@ -64,7 +82,8 @@ class RelationTestHelper:
         # update specifics
         self.view_relation.materialization = mz.VIEW
 
-        for n in ('downstream_relation', 'upstream_relation',):
+        for n in ('downstream_relation', 'upstream_relation', 'downstream_wildcard_relation_1', 'downstream_wildcard_relation_2',
+                'upstream_wildcard_relation_1', 'upstream_wildcard_relation_2'):
             self.__dict__[n].attributes = [
                 Attribute(self.directional_key, dt.INTEGER)]
 
@@ -73,7 +92,8 @@ class RelationTestHelper:
         self.birelation_left.attributes = [
             Attribute(self.bidirectional_key_left, dt.VARCHAR)]
 
-        for r in ('downstream_relation', 'upstream_relation', 'iso_relation', 'birelation_left', 'birelation_right', 'view_relation',):
+        for r in ('downstream_relation', 'upstream_relation', 'iso_relation', 'birelation_left', 'birelation_right', 'view_relation',
+                'downstream_wildcard_relation_1', 'downstream_wildcard_relation_2', 'upstream_wildcard_relation_1', 'upstream_wildcard_relation_2'):
             self.__dict__[r].compiled_query = ''
 
 

--- a/tests/conftest_modules/test_configuration.py
+++ b/tests/conftest_modules/test_configuration.py
@@ -1,4 +1,43 @@
 
+BASIC_CONFIGURATION = {
+    "version": "1",
+    "credpath": "tests/assets/integration/credentials.yml",
+    "name": "integration trail path",
+    "short_description": "this is a sample with LIVE CREDS for integration",
+    "long_description": "this is for testing against a live db",
+    "threads": 15,
+    "source": {
+        "profile": "default",
+        "sampling": "default",
+        "general_relations": {
+            "databases": [
+                {
+                    "pattern": "SNOWSHU_DEVELOPMENT",
+                    "schemas": [
+                        {
+                            "pattern": ".*",
+                            "relations": [
+                                "^(?!.+_VIEW).+$"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "include_outliers": True,
+        "specified_relations": []
+    },
+    "target": {
+        "adapter": "postgres",
+        "adapter_args": {
+            "pg_extensions": ["citext"]
+        }
+    },
+    "storage": {
+        "profile": "default"
+    }
+}
+
 
 CONFIGURATION = {
     "version": "1",

--- a/tests/unit/test_config_regex.py
+++ b/tests/unit/test_config_regex.py
@@ -51,7 +51,7 @@ MOCKED_CATALOG = (Relation('snowyes', 'thing', 'foo_suffix', mz.TABLE, []),
                            'nevermatch_except_bidirectional', mz.TABLE, []),
                   Relation('snowyes', 'thing', 'nevermatch_except_bidirectional', mz.TABLE, []),)
 
-
+@pytest.mark.skip("TODO This test needs to be redone since the filtering is completed when the catalog is created, not during graph building")
 @mock.patch('snowshu.core.configuration_parser.ConfigurationParser._build_adapter_profile')
 @mock.patch('snowshu.core.configuration_parser.ConfigurationParser._build_target')
 def test_included_and_excluded(target, adapter):

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -11,7 +11,7 @@ from snowshu.core.graph import SnowShuGraph
 from snowshu.core.models import Relation
 from snowshu.core.models import materializations as mz
 from snowshu.samplings.samplings import BruteForceSampling, DefaultSampling
-from tests.conftest import CONFIGURATION
+from tests.conftest import CONFIGURATION, BASIC_CONFIGURATION
 
 
 def test_graph_builds_dags_correctly(stub_graph_set):
@@ -107,7 +107,7 @@ def test_sets_outliers(stub_graph_set):
                     vals.birelation_left,
                     vals.birelation_right]
 
-    config_dict=copy.deepcopy(CONFIGURATION)
+    config_dict=copy.deepcopy(BASIC_CONFIGURATION)
     config_dict['source']['include_outliers']=True
     config_dict['source']['max_number_of_outliers']=1000
 
@@ -134,7 +134,7 @@ def test_no_duplicates(stub_graph_set):
                     vals.birelation_left,
                     vals.birelation_right]
 
-    config_dict=copy.deepcopy(CONFIGURATION)
+    config_dict=copy.deepcopy(BASIC_CONFIGURATION)
 
     config=ConfigurationParser().from_file_or_path(StringIO(yaml.dump(config_dict)))
     

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -1,5 +1,6 @@
 import copy
 from io import StringIO
+from snowshu.exceptions import InvalidRelationshipException
 
 import mock
 import networkx as nx
@@ -63,7 +64,6 @@ def test_graph_allows_upstream_wildcards(stub_graph_set):
 
     modified_graph = shgraph._apply_specifications(
         config, nx.DiGraph(), full_catalog)
-
     assert (vals.upstream_relation, vals.downstream_relation,
             ) in modified_graph.edges
 
@@ -94,6 +94,7 @@ def test_unsampled(stub_graph_set):
     modified_graph=shgraph._apply_specifications(config,nx.DiGraph(),full_catalog)       
  
     assert vals.iso_relation.unsampled==True
+
 
 def test_sets_outliers(stub_graph_set):
     shgraph=SnowShuGraph()
@@ -147,6 +148,7 @@ def test_no_duplicates(stub_graph_set):
     all_nodes=[node for graph in graphs for node in graph.nodes]
     assert len(set(all_nodes)) == len(all_nodes)
 
+
 def test_split_dag_to_parallel():
     shgraph=SnowShuGraph()
     dag=nx.DiGraph()
@@ -180,3 +182,181 @@ def test_sets_only_existing_adapters():
     
     assert isinstance(shgraph._set_overriding_params_for_node(test_relation,config).sampling,
                       BruteForceSampling)
+
+
+def test_build_graph_fails_no_downstream():
+    """ Tests build_graph exits on no downstream relations """
+    shgraph = SnowShuGraph()
+    full_catalog=[]  # no relations in filtered catalog
+    config_dict=copy.deepcopy(CONFIGURATION)  # use the "live" config on random test data
+    config=ConfigurationParser().from_file_or_path(StringIO(yaml.dump(config_dict)))
+
+    with mock.MagicMock() as adapter_mock:
+        adapter_mock.build_catalog.return_value = full_catalog
+        config.source_profile.adapter = adapter_mock
+
+        with pytest.raises(InvalidRelationshipException) as exc:
+            # building the graph should raise when no downstream relations are found
+            shgraph.build_graph(config)
+        assert "does not match any relations" in str(exc.value)
+
+
+def test_build_graph_fails_no_upstream(stub_graph_set):
+    """ Tests build_graph exits on no upstream relations """
+    shgraph = SnowShuGraph()
+    _,vals = stub_graph_set
+    full_catalog = [
+                    vals.iso_relation,
+                    vals.view_relation,
+                    vals.downstream_relation,
+                ]
+    config_dict = copy.deepcopy(BASIC_CONFIGURATION)
+    config_dict["source"]["specified_relations"] = [
+        {
+            "database": vals.downstream_relation.database,
+            "schema": vals.downstream_relation.schema,
+            "relation": vals.downstream_relation.name,
+            "relationships": {
+                "directional": [
+                    {
+                        "local_attribute": vals.directional_key,
+                        "database": vals.upstream_relation.database,
+                        "schema": vals.upstream_relation.schema,
+                        "relation": vals.upstream_relation.name,
+                        "remote_attribute": vals.directional_key
+                    }
+                ]
+            }
+        }
+    ]
+    config = ConfigurationParser().from_file_or_path(StringIO(yaml.dump(config_dict)))
+
+    with mock.MagicMock() as adapter_mock:
+        adapter_mock.build_catalog.return_value = full_catalog
+        config.source_profile.adapter = adapter_mock
+
+        with pytest.raises(InvalidRelationshipException) as exc:
+            shgraph.build_graph(config)
+        assert "was specified as a dependency, but it does not exist." in str(exc.value)
+
+
+def test_build_graph_fails_no_distinct_upstream(stub_graph_set):
+    """ Tests build_graph exits on no distinct upstream relations """
+    shgraph = SnowShuGraph()
+    _,vals = stub_graph_set
+    full_catalog = [
+                    vals.iso_relation,
+                    vals.view_relation,
+                    vals.downstream_relation,
+                    vals.upstream_relation,
+                ]
+    config_dict = copy.deepcopy(BASIC_CONFIGURATION)
+    # add relationship where downstream == upstream
+    config_dict["source"]["specified_relations"] = [
+        {
+            "database": vals.downstream_relation.database,
+            "schema": vals.downstream_relation.schema,
+            "relation": vals.downstream_relation.name,
+            "relationships": {
+                "directional": [
+                    {
+                        "local_attribute": vals.directional_key,
+                        "database": vals.downstream_relation.database,
+                        "schema": vals.downstream_relation.schema,
+                        "relation": vals.downstream_relation.name,
+                        "remote_attribute": vals.directional_key
+                    }
+                ]
+            }
+        }
+    ]
+    config = ConfigurationParser().from_file_or_path(StringIO(yaml.dump(config_dict)))
+
+    with mock.MagicMock() as adapter_mock:
+        adapter_mock.build_catalog.return_value = full_catalog
+        config.source_profile.adapter = adapter_mock
+
+        with pytest.raises(InvalidRelationshipException) as exc:
+            shgraph.build_graph(config)
+        assert "was specified as a dependency, but it does not exist." in str(exc.value)
+
+
+def test_build_graph_fails_many_to_many(stub_graph_set):
+    """ Tests build_graph exits on many-to-many relationships """
+    shgraph = SnowShuGraph()
+    _,vals = stub_graph_set
+    full_catalog=[  vals.iso_relation,
+                    vals.view_relation,
+                    vals.downstream_relation,
+                    vals.upstream_relation,
+                    vals.birelation_left,
+                    vals.birelation_right]
+    config_dict=copy.deepcopy(BASIC_CONFIGURATION)
+    config_dict["source"]["specified_relations"] = [
+        {
+            "database": ".*",
+            "schema": ".*",
+            "relation": ".*relation_.*$", # birelations
+            "relationships": {
+                "directional": [
+                    {
+                        "local_attribute": vals.directional_key,
+                        "database": ".*",
+                        "schema": ".*",
+                        "relation": ".*relation$", # non birelations
+                        "remote_attribute": vals.directional_key
+                    }
+                ]
+            }
+        }
+    ]
+    config=ConfigurationParser().from_file_or_path(StringIO(yaml.dump(config_dict)))
+
+    with mock.MagicMock() as adapter_mock:
+        adapter_mock.build_catalog.return_value = full_catalog
+        config.source_profile.adapter = adapter_mock
+
+        with pytest.raises(InvalidRelationshipException) as exc:
+            shgraph.build_graph(config)
+        assert "defines a many-to-many relationship" in str(exc.value)
+        assert "Many-to-many relationship are not allowed by SnowShu" in str(exc.value)
+
+
+def test_build_graph_fails_view(stub_graph_set):
+    """ Tests build_graph exits on views as upstream relations """
+    shgraph = SnowShuGraph()
+    _,vals = stub_graph_set
+    full_catalog=[  vals.iso_relation,
+                    vals.view_relation,
+                    vals.downstream_relation,
+                    vals.upstream_relation,
+                    vals.birelation_left,
+                    vals.birelation_right]
+    config_dict=copy.deepcopy(BASIC_CONFIGURATION)
+    config_dict["source"]["specified_relations"] = [
+        {
+            "database": vals.downstream_relation.database,
+            "schema": vals.downstream_relation.schema,
+            "relation": vals.downstream_relation.name,
+            "relationships": {
+                "directional": [
+                    {
+                        "local_attribute": vals.directional_key,
+                        "database": vals.view_relation.database,
+                        "schema": vals.view_relation.schema,
+                        "relation": vals.view_relation.name,
+                        "remote_attribute": vals.directional_key
+                    }
+                ]
+            }
+        }
+    ]
+    config=ConfigurationParser().from_file_or_path(StringIO(yaml.dump(config_dict)))
+
+    with mock.MagicMock() as adapter_mock:
+        adapter_mock.build_catalog.return_value = full_catalog
+        config.source_profile.adapter = adapter_mock
+
+        with pytest.raises(InvalidRelationshipException) as exc:
+            shgraph.build_graph(config)
+        assert "View dependencies are not allowed by SnowShu." in str(exc.value)


### PR DESCRIPTION
This PR primarily adds support for regex in the upstream/remote relation definitions in the `specified_relations` section of the config. To properly support it, a reworking of the way that the graphs are built was required.

The following config should now be supported:
``` yaml
  - database: my_db
    schema: my_schema
    relation: my_table
    relationships:
      directional:
      - local_attribute: local_attr
        database: ''
        schema: ''
        relation: [upstream]_.*_tables
        remote_attribute: remote_attr
```

**Changes**
* Removed unnecessary refiltering of catalog in `SnowShuGraph`
  * Marked `test_included_and_excluded` as skip since it is no longer relevant due to previous changes where the filtering was happening
* Reworked and refactored `_apply_specifications` to support regex for the upstream relation
  * A side effect of this is a more correct handling of the `''` partitioned wildcard during graph building
* Added errors for no downstream relations, no upstream relations, or defining a many-to-many relationship
* Added tests for those errors and many-to-1 upstream relations