### PR TITLE
Adding polymorphic table support

### DIFF
--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -252,12 +252,12 @@ LIMIT {max_number_of_outliers})
         return f"{local_key} IN ({constraint_sql}) "
 
     @staticmethod
-    def polymorphic_constraint_statement(relation: Relation,
-                                       analyze: bool,
-                                       local_key: str,
-                                       remote_key: str,
-                                       local_type: str,
-                                       local_type_match_val: str = None) -> str:
+    def polymorphic_constraint_statement(relation: Relation,  # noqa pylint: disable=too-many-arguments
+                                         analyze: bool,
+                                         local_key: str,
+                                         remote_key: str,
+                                         local_type: str,
+                                         local_type_match_val: str = None) -> str:
         predicate = SnowflakeAdapter.predicate_constraint_statement(relation, analyze, local_key, remote_key)
         if local_type_match_val:
             type_match_val = local_type_match_val

--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -252,6 +252,20 @@ LIMIT {max_number_of_outliers})
         return f"{local_key} IN ({constraint_sql}) "
 
     @staticmethod
+    def polymorphic_constraint_statement(relation: Relation,
+                                       analyze: bool,
+                                       local_key: str,
+                                       remote_key: str,
+                                       local_type: str,
+                                       local_type_match_val: str = None) -> str:
+        predicate = SnowflakeAdapter.predicate_constraint_statement(relation, analyze, local_key, remote_key)
+        if local_type_match_val:
+            type_match_val = local_type_match_val
+        else:
+            type_match_val = relation.name[:-1] if relation.name[-1].lower() == 's' else relation.name
+        return f" ({predicate} AND LOWER({local_type}) = LOWER('{type_match_val}') ) "
+
+    @staticmethod
     def _sample_type_to_query_sql(sample_type: 'BaseSampleMethod') -> str:
         if sample_type.name == 'BERNOULLI':
             qualifier = sample_type.probability if sample_type.probability\

--- a/snowshu/core/compile.py
+++ b/snowshu/core/compile.py
@@ -1,3 +1,4 @@
+from snowshu.exceptions import InvalidRelationshipException
 from typing import Type
 
 import networkx
@@ -39,6 +40,7 @@ class RuntimeSourceCompiler:
             do_not_sample = False
             predicates = list()
             unions = list()
+            polymorphic_predicates = list()
             for child in dag.successors(relation):
                 # parallel edges aren't currently supported
                 edge = dag.edges[relation, child]
@@ -46,7 +48,10 @@ class RuntimeSourceCompiler:
                     predicates.append(source_adapter.upstream_constraint_statement(child,
                                                                                    edge['remote_attribute'],
                                                                                    edge['local_attribute']))
-                if relation.include_outliers:
+                if relation.include_outliers and edge['direction'] == 'polymorphic':
+                    logger.warning("Polymorphic relationships currently do not support including outliers. "
+                                   f"Ignoring include_outliers flag for edge from {relation.dot_notation} to {child.dot_notation}. ")
+                elif relation.include_outliers:
                     unions.append(source_adapter.union_constraint_statement(relation,
                                                                             child,
                                                                             edge['remote_attribute'],
@@ -55,18 +60,42 @@ class RuntimeSourceCompiler:
 
             for parent in dag.predecessors(relation):
                 edge = dag.edges[parent, relation]
-                # if any incoming edge is birectional set do_not_sample flag
-                do_not_sample = (edge['direction'] == 'bidirectional' or do_not_sample)
-                predicates.append(source_adapter.predicate_constraint_statement(parent,
-                                                                                analyze,
-                                                                                edge['local_attribute'],
-                                                                                edge['remote_attribute']))
-                if relation.include_outliers:
+                # if any incoming edge is birectional or polymorphic set do_not_sample flag
+                # do_not_sample is set since those types are most likely already restricted
+                do_not_sample = (edge['direction'] in ('bidirectional', 'polymorphic',) or do_not_sample)
+                if edge['direction'] == 'polymorphic':
+                    # if the local type attribute is set, the constraint needs to account for it
+                    # otherwise we only need the normal predicate constraint
+                    if edge['local_type_attribute']:
+                        polymorphic_predicates.append(source_adapter.polymorphic_constraint_statement(parent,
+                                                                                                      analyze,
+                                                                                                      edge['local_attribute'],
+                                                                                                      edge['remote_attribute'],
+                                                                                                      edge['local_type_attribute']))
+                    else:
+                        polymorphic_predicates.append(source_adapter.predicate_constraint_statement(parent,
+                                                                                                    analyze,
+                                                                                                    edge['local_attribute'],
+                                                                                                    edge['remote_attribute']))
+                else:
+                    predicates.append(source_adapter.predicate_constraint_statement(parent,
+                                                                                    analyze,
+                                                                                    edge['local_attribute'],
+                                                                                    edge['remote_attribute']))
+                if relation.include_outliers and edge['direction'] == 'polymorphic':
+                    logger.warning("Polymorphic relationships currently do not support including outliers. "
+                                   f"Ignoring include_outliers flag for edge from {parent.dot_notation} to {relation.dot_notation}. ")
+                elif relation.include_outliers:
                     unions.append(source_adapter.union_constraint_statement(relation,
                                                                             parent,
                                                                             edge['local_attribute'],
                                                                             edge['remote_attribute'],
                                                                             relation.max_number_of_outliers))
+
+            # if polymorphic predicates are set up, then generate the or predicate
+            if polymorphic_predicates:
+                full_polymorphic_predicate = " OR ".join(polymorphic_predicates)
+                predicates.append(f"( {full_polymorphic_predicate} )")
 
             query = source_adapter.sample_statement_from_relation(
                 relation, (None if predicates else relation.sampling.sample_method))

--- a/snowshu/core/compile.py
+++ b/snowshu/core/compile.py
@@ -67,13 +67,15 @@ class RuntimeSourceCompiler:
                 if edge['direction'] == 'polymorphic':
                     # if the local type attribute is set, the constraint needs to account for it
                     # otherwise we only need the normal predicate constraint
-                    if edge['local_type_attribute']:
+                    if 'local_type_attribute' in edge:
+                        local_type_override = edge['local_type_overrides'].get(parent.dot_notation, None)
                         polymorphic_predicates.append(
                             source_adapter.polymorphic_constraint_statement(parent,
                                                                             analyze,
                                                                             edge['local_attribute'],
                                                                             edge['remote_attribute'],
-                                                                            edge['local_type_attribute']))
+                                                                            edge['local_type_attribute'],
+                                                                            local_type_override))
                     else:
                         polymorphic_predicates.append(
                             source_adapter.predicate_constraint_statement(parent,

--- a/snowshu/core/compile.py
+++ b/snowshu/core/compile.py
@@ -1,4 +1,3 @@
-from snowshu.exceptions import InvalidRelationshipException
 from typing import Type
 
 import networkx
@@ -13,8 +12,9 @@ logger = Logger().logger
 
 class RuntimeSourceCompiler:
 
+    # TODO breakout edge logic into edgetype/direction handling functions
     @staticmethod   # noqa mccabe: disable=MC0001
-    def compile_queries_for_relation(relation: Relation,
+    def compile_queries_for_relation(relation: Relation,  # noqa pylint: disable=too-many-branches
                                      dag: networkx.Graph,
                                      source_adapter: Type[BaseSourceAdapter],
                                      analyze: bool) -> Relation:
@@ -50,7 +50,8 @@ class RuntimeSourceCompiler:
                                                                                    edge['local_attribute']))
                 if relation.include_outliers and edge['direction'] == 'polymorphic':
                     logger.warning("Polymorphic relationships currently do not support including outliers. "
-                                   f"Ignoring include_outliers flag for edge from {relation.dot_notation} to {child.dot_notation}. ")
+                                   "Ignoring include_outliers flag for edge "
+                                   f"from {relation.dot_notation} to {child.dot_notation}. ")
                 elif relation.include_outliers:
                     unions.append(source_adapter.union_constraint_statement(relation,
                                                                             child,
@@ -67,16 +68,18 @@ class RuntimeSourceCompiler:
                     # if the local type attribute is set, the constraint needs to account for it
                     # otherwise we only need the normal predicate constraint
                     if edge['local_type_attribute']:
-                        polymorphic_predicates.append(source_adapter.polymorphic_constraint_statement(parent,
-                                                                                                      analyze,
-                                                                                                      edge['local_attribute'],
-                                                                                                      edge['remote_attribute'],
-                                                                                                      edge['local_type_attribute']))
+                        polymorphic_predicates.append(
+                            source_adapter.polymorphic_constraint_statement(parent,
+                                                                            analyze,
+                                                                            edge['local_attribute'],
+                                                                            edge['remote_attribute'],
+                                                                            edge['local_type_attribute']))
                     else:
-                        polymorphic_predicates.append(source_adapter.predicate_constraint_statement(parent,
-                                                                                                    analyze,
-                                                                                                    edge['local_attribute'],
-                                                                                                    edge['remote_attribute']))
+                        polymorphic_predicates.append(
+                            source_adapter.predicate_constraint_statement(parent,
+                                                                          analyze,
+                                                                          edge['local_attribute'],
+                                                                          edge['remote_attribute']))
                 else:
                     predicates.append(source_adapter.predicate_constraint_statement(parent,
                                                                                     analyze,
@@ -84,7 +87,8 @@ class RuntimeSourceCompiler:
                                                                                     edge['remote_attribute']))
                 if relation.include_outliers and edge['direction'] == 'polymorphic':
                     logger.warning("Polymorphic relationships currently do not support including outliers. "
-                                   f"Ignoring include_outliers flag for edge from {parent.dot_notation} to {relation.dot_notation}. ")
+                                   "Ignoring include_outliers flag for edge "
+                                   f"from {parent.dot_notation} to {relation.dot_notation}. ")
                 elif relation.include_outliers:
                     unions.append(source_adapter.union_constraint_statement(relation,
                                                                             parent,

--- a/snowshu/core/configuration_parser.py
+++ b/snowshu/core/configuration_parser.py
@@ -59,9 +59,14 @@ class SpecifiedMatchPattern():
         remote_attribute: str
 
     @dataclass
+    class PolymorphicRelationshipPattern(RelationshipPattern):
+        local_type_attribute: str
+
+    @dataclass
     class Relationships:
         bidirectional: List['RelationshipPattern']  # noqa pyflakes: disable=F821
         directional: List['RelationshipPattern']    # noqa pyflakes: disable=F821
+        polymorphic: List['PolymorphicRelationshipPattern']    # noqa pyflakes: disable=F821
 
     database_pattern: str
     schema_pattern: str
@@ -236,12 +241,26 @@ class ConfigurationParser:
                 self.case(sub['relation']),
                 self.case(sub['remote_attribute']))
 
+        def build_polymorphic_relationship(
+                sub) -> SpecifiedMatchPattern.PolymorphicRelationshipPattern:
+            return SpecifiedMatchPattern.PolymorphicRelationshipPattern(
+                self.case(sub['local_attribute']),
+                self.case(sub['database']) if sub['database'] != '' else None,
+                self.case(sub['schema']) if sub['schema'] != '' else None,
+                self.case(sub['relation']),
+                self.case(sub['remote_attribute']),
+                self.case(sub['local_type_attribute']) if sub['local_type_attribute'] != '' else None
+            )
+
         relationships = specified_pattern.get('relationships', dict())
         directional = relationships.get('directional', list())
         bidirectional = relationships.get('bidirectional', list())
+        polymorphic = relationships.get('polymorphic', list())
         return SpecifiedMatchPattern.Relationships(
             [build_relationship(rel) for rel in bidirectional],
-            [build_relationship(rel) for rel in directional])
+            [build_relationship(rel) for rel in directional],
+            [build_polymorphic_relationship(rel) for rel in polymorphic]
+        )
 
     def _build_specified_relations(
             self, source_config: dict) -> SpecifiedMatchPattern:

--- a/snowshu/core/configuration_parser.py
+++ b/snowshu/core/configuration_parser.py
@@ -61,6 +61,7 @@ class SpecifiedMatchPattern():
     @dataclass
     class PolymorphicRelationshipPattern(RelationshipPattern):
         local_type_attribute: str
+        local_type_overrides: dict
 
     @dataclass
     class Relationships:
@@ -243,13 +244,25 @@ class ConfigurationParser:
 
         def build_polymorphic_relationship(
                 sub) -> SpecifiedMatchPattern.PolymorphicRelationshipPattern:
+            override_dict = {}
+            if 'local_type_overrides' in sub:
+                for override in sub['local_type_overrides']:
+                    key = '.'.join([
+                        self.case(override['database']),
+                        self.case(override['schema']),
+                        self.case(override['relation'])
+                    ])
+                    value = override['override_value']
+                    override_dict[key] = value
+
             return SpecifiedMatchPattern.PolymorphicRelationshipPattern(
                 self.case(sub['local_attribute']),
                 self.case(sub['database']) if sub['database'] != '' else None,
                 self.case(sub['schema']) if sub['schema'] != '' else None,
                 self.case(sub['relation']),
                 self.case(sub['remote_attribute']),
-                self.case(sub['local_type_attribute']) if sub['local_type_attribute'] != '' else None
+                self.case(sub['local_type_attribute']) if 'local_type_attribute' in sub else None,
+                override_dict
             )
 
         relationships = specified_pattern.get('relationships', dict())

--- a/snowshu/core/graph.py
+++ b/snowshu/core/graph.py
@@ -134,19 +134,23 @@ class SnowShuGraph:
                         }
                     ) for val in relation.relationships.__dict__[relationship_type]]
 
-            for relationship_type in ('polymorphic',):
-                relationship_dicts += [
-                    dict(
-                        database=val.database_pattern,
-                        schema=val.schema_pattern,
-                        name=val.relation_pattern,
-                        edge_attributes={
-                            "direction": relationship_type,
-                            "remote_attribute": val.remote_attribute,
-                            "local_attribute": val.local_attribute,
-                            "local_type_attribute": val.local_type_attribute
-                        }
-                    ) for val in relation.relationships.__dict__[relationship_type]]
+            for val in relation.relationships.polymorphic:
+                edge_attr = {
+                    "direction": "polymorphic",
+                    "remote_attribute": val.remote_attribute,
+                    "local_attribute": val.local_attribute,
+                }
+                if val.local_type_attribute:
+                    edge_attr["local_type_attribute"] = val.local_type_attribute
+                    edge_attr["local_type_overrides"] = val.local_type_overrides
+
+                rel_dict = {
+                    "database": val.database_pattern,
+                    "schema": val.schema_pattern,
+                    "name": val.relation_pattern,
+                    "edge_attributes": edge_attr
+                }
+                relationship_dicts.append(rel_dict)
 
             # determine downstream relations from relation patterns
             downstream_relations = set(

--- a/snowshu/core/graph.py
+++ b/snowshu/core/graph.py
@@ -308,7 +308,7 @@ class SnowShuGraph:
                 schema=lower_level.schema_pattern if lower_level.schema_pattern else upper_level.schema_pattern,
                 name=lower_level.relation_pattern
             ) for upper_level in config.specified_relations
-            for lower_level in upper_level.relationships.bidirectional + upper_level.relationships.directional
+            for lower_level in upper_level.relationships.bidirectional + upper_level.relationships.directional + upper_level.relationships.polymorphic
         ]
 
         all_patterns = approved_default_patterns + \

--- a/snowshu/core/graph.py
+++ b/snowshu/core/graph.py
@@ -124,12 +124,28 @@ class SnowShuGraph:
             for relationship_type in ('bidirectional', 'directional',):
                 relationship_dicts += [
                     dict(
-                        direction=relationship_type,
                         database=val.database_pattern,
                         schema=val.schema_pattern,
                         name=val.relation_pattern,
-                        remote_attribute=val.remote_attribute,
-                        local_attribute=val.local_attribute
+                        edge_attributes={
+                            "direction": relationship_type,
+                            "remote_attribute": val.remote_attribute,
+                            "local_attribute": val.local_attribute
+                        }
+                    ) for val in relation.relationships.__dict__[relationship_type]]
+
+            for relationship_type in ('polymorphic',):
+                relationship_dicts += [
+                    dict(
+                        database=val.database_pattern,
+                        schema=val.schema_pattern,
+                        name=val.relation_pattern,
+                        edge_attributes={
+                            "direction": relationship_type,
+                            "remote_attribute": val.remote_attribute,
+                            "local_attribute": val.local_attribute,
+                            "local_type_attribute": val.local_type_attribute
+                        }
                     ) for val in relation.relationships.__dict__[relationship_type]]
 
             # determine downstream relations from relation patterns
@@ -233,9 +249,7 @@ class SnowShuGraph:
             for upstream_relation in upstream_without_downstream:
                 graph.add_edge(upstream_relation,
                                downstream_relation,
-                               direction=relationship['direction'],
-                               remote_attribute=relationship['remote_attribute'],
-                               local_attribute=relationship['local_attribute'])
+                               **relationship['edge_attributes'])
         return graph
 
     def get_graphs(self) -> tuple:

--- a/snowshu/core/graph.py
+++ b/snowshu/core/graph.py
@@ -308,7 +308,7 @@ class SnowShuGraph:
                 schema=lower_level.schema_pattern if lower_level.schema_pattern else upper_level.schema_pattern,
                 name=lower_level.relation_pattern
             ) for upper_level in config.specified_relations
-            for lower_level in upper_level.relationships.bidirectional + upper_level.relationships.directional + upper_level.relationships.polymorphic
+            for lower_level in upper_level.relationships.bidirectional + upper_level.relationships.directional + upper_level.relationships.polymorphic  # noqa pep8: E501
         ]
 
         all_patterns = approved_default_patterns + \

--- a/snowshu/templates/replica_schema.json
+++ b/snowshu/templates/replica_schema.json
@@ -166,6 +166,12 @@
               "items": {
                 "$ref": "#/definitions/_directional_relationship_object"
               }
+            },
+            "polymorphic": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/_polymorphic_relationship_object"
+              }
             }
           },
           "additionalProperties": false,
@@ -186,6 +192,37 @@
       "additionalProperties": false,
       "properties": {
         "local_attribute": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "relation": {
+          "type": "string"
+        },
+        "remote_attribute": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "local_attribute",
+        "database",
+        "schema",
+        "relation",
+        "remote_attribute"
+      ]
+    },
+    "_polymorphic_relationship_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "local_attribute": {
+          "type": "string"
+        },
+        "local_type_attribute": {
           "type": "string"
         },
         "database": {

--- a/snowshu/templates/replica_schema.json
+++ b/snowshu/templates/replica_schema.json
@@ -217,12 +217,19 @@
     },
     "_polymorphic_relationship_object": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "local_attribute": {
+      "additionalProperties": {
+        "local_type_attribute": {
           "type": "string"
         },
-        "local_type_attribute": {
+        "local_type_overrides": {
+          "type": "array",
+          "items":{
+            "type": "object"
+          }
+        }
+      },
+      "properties": {
+        "local_attribute": {
           "type": "string"
         },
         "database": {

--- a/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/child_type_0_items.csv
+++ b/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/child_type_0_items.csv
@@ -1,0 +1,5 @@
+id,parent_2_id,value
+1,1,child_type_0_1
+2,4,child_type_0_2
+3,7,child_type_0_3
+4,10,child_type_0_4

--- a/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/child_type_1_items.csv
+++ b/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/child_type_1_items.csv
@@ -1,0 +1,5 @@
+id,parent_2_id,value
+1,2,child_type_1_1
+2,5,child_type_1_2
+3,8,child_type_1_3
+4,11,child_type_1_4

--- a/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/child_type_2_items.csv
+++ b/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/child_type_2_items.csv
@@ -1,0 +1,5 @@
+id,parent_2_id,value
+1,3,child_type_2_1
+2,6,child_type_2_2
+3,9,child_type_2_3
+4,12,child_type_2_4

--- a/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/parent_table.csv
+++ b/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/parent_table.csv
@@ -11,3 +11,5 @@ id,child_id,child_type,value
 10,2,child_type_2_item,parent_10
 11,3,child_type_2_item,parent_11
 12,4,child_type_2_item,parent_12
+13,1,child_type_x_item,parent_13
+14,2,child_type_x_item,parent_14

--- a/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/parent_table.csv
+++ b/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/parent_table.csv
@@ -7,9 +7,9 @@ id,child_id,child_type,value
 6,2,child_type_1_item,parent_6
 7,3,child_type_1_item,parent_7
 8,4,child_type_1_item,parent_8
-9,1,child_type_2_item,parent_9
-10,2,child_type_2_item,parent_10
-11,3,child_type_2_item,parent_11
-12,4,child_type_2_item,parent_12
+9,1,type_2,parent_9
+10,2,type_2,parent_10
+11,3,type_2,parent_11
+12,4,type_2,parent_12
 13,1,child_type_x_item,parent_13
 14,2,child_type_x_item,parent_14

--- a/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/parent_table.csv
+++ b/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/parent_table.csv
@@ -1,0 +1,13 @@
+id,child_id,child_type,value
+1,1,child_type_0_item,parent_1
+2,2,child_type_0_item,parent_2
+3,3,child_type_0_item,parent_3
+4,4,child_type_0_item,parent_4
+5,1,child_type_1_item,parent_5
+6,2,child_type_1_item,parent_6
+7,3,child_type_1_item,parent_7
+8,4,child_type_1_item,parent_8
+9,1,child_type_2_item,parent_9
+10,2,child_type_2_item,parent_10
+11,3,child_type_2_item,parent_11
+12,4,child_type_2_item,parent_12

--- a/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/parent_table_2.csv
+++ b/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/parent_table_2.csv
@@ -11,3 +11,5 @@ id,value
 10,parent_2_10
 11,parent_2_11
 12,parent_2_12
+13,parent_2_13
+14,parent_2_14

--- a/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/parent_table_2.csv
+++ b/tests/assets/data/DATABASE=SNOWSHU_DEVELOPMENT/SCHEMA=POLYMORPHIC_DATA/parent_table_2.csv
@@ -1,0 +1,13 @@
+id,value
+1,parent_2_1
+2,parent_2_2
+3,parent_2_3
+4,parent_2_4
+5,parent_2_5
+6,parent_2_6
+7,parent_2_7
+8,parent_2_8
+9,parent_2_9
+10,parent_2_10
+11,parent_2_11
+12,parent_2_12

--- a/tests/assets/replica_test_config.yml
+++ b/tests/assets/replica_test_config.yml
@@ -1,0 +1,93 @@
+version: "1"
+credpath: "./tests/assets/integration/credentials.yml" ## can be a relative or expandable path
+name: integration-test
+short_description: this is a sample with LIVE CREDS for integration
+long_description: this is for testing against a live db
+threads: 15
+target:
+  adapter: 'postgres'
+  adapter_args:
+    pg_extensions:
+      - citext
+source:
+  profile: default
+  sampling: default
+  include_outliers: True
+  general_relations:
+    databases:
+      - pattern: SNOWSHU_DEVELOPMENT # matches our test database
+        schemas:
+          - pattern: "(?i)(EXTERNAL_DATA|SOURCE_SYSTEM|TESTS_DATA)" # matches our test schemas
+            relations:
+              - '(?i)^.*(?<!_view)$' # matches all relations that do not end with '_VIEW'
+  # these are exceptions to the 'default' sampling above
+  specified_relations: 
+    - database: SNOWSHU_DEVELOPMENT
+      schema: SOURCE_SYSTEM
+      relation: ORDERS
+      unsampled: True
+    - database: SNOWSHU_DEVELOPMENT
+      schema: SOURCE_SYSTEM
+      relation: ORDER_ITEMS_VIEW
+      unsampled: True
+    - database: SNOWSHU_DEVELOPMENT
+      schema: TESTS_DATA
+      relation: DATA_TYPES
+      unsampled: True
+        
+    - database: SNOWSHU_DEVELOPMENT
+      schema: SOURCE_SYSTEM
+      relation: ORDER_ITEMS
+      relationships:
+        bidirectional: 
+          - local_attribute: PRODUCT_ID 
+            database: '' ## empty strings inherit from the downstream relation
+            schema: ''
+            relation: PRODUCTS
+            remote_attribute: ID
+        directional: 
+          - local_attribute: ORDER_ID
+            database: SNOWSHU_DEVELOPMENT
+            schema: SOURCE_SYSTEM
+            relation: ORDERS
+            remote_attribute: ID
+    - database: SNOWSHU_DEVELOPMENT
+      schema: SOURCE_SYSTEM
+      relation: USER_COOKIES
+      relationships:
+        bidirectional: 
+          - local_attribute: USER_ID 
+            database: '' ## empty strings inherit from the downstream relation
+            schema: ''
+            relation: USERS
+            remote_attribute: ID
+    - database: SNOWSHU_DEVELOPMENT
+      schema: EXTERNAL_DATA
+      relation: SOCIAL_USERS_IMPORT
+      sampling:
+        default:
+          margin_of_error: 0.05
+          confidence: 0.95
+          min_sample_size: 300
+    - database: SNOWSHU_DEVELOPMENT
+      schema: POLYMORPHIC_DATA
+      relation: PARENT_TABLE
+      relationships:
+        polymorphic:
+          - local_attribute: CHILD_ID
+            local_type_attribute: CHILD_TYPE
+            database: ''
+            schema: ''
+            relation: '(?i)^CHILD_TYPE_[0-9]_ITEMS$'
+            remote_attribute: ID
+    - database: SNOWSHU_DEVELOPMENT
+      schema: POLYMORPHIC_DATA
+      relation: PARENT_TABLE_2
+      relationships:
+        polymorphic:
+          - local_attribute: PARENT_ID
+            local_type_attribute: ''
+            database: SNOWSHU_DEVELOPMENT
+            schema: POLYMORPHIC_DATA
+            relation: '(?i)^CHILD_TYPE_[0-9]_ITEMS$'
+            remote_attribute: PARENT_ID

--- a/tests/assets/replica_test_config.yml
+++ b/tests/assets/replica_test_config.yml
@@ -85,7 +85,7 @@ source:
       relation: PARENT_TABLE_2
       relationships:
         polymorphic:
-          - local_attribute: PARENT_ID
+          - local_attribute: ID
             local_type_attribute: ''
             database: SNOWSHU_DEVELOPMENT
             schema: POLYMORPHIC_DATA

--- a/tests/assets/replica_test_config.yml
+++ b/tests/assets/replica_test_config.yml
@@ -80,13 +80,17 @@ source:
             schema: ''
             relation: '(?i)^CHILD_TYPE_[0-9]_ITEMS$'
             remote_attribute: ID
+            local_type_overrides:
+              - database: SNOWSHU_DEVELOPMENT
+                schema: POLYMORPHIC_DATA
+                relation: CHILD_TYPE_2_ITEMS
+                override_value: type_2
     - database: SNOWSHU_DEVELOPMENT
       schema: POLYMORPHIC_DATA
       relation: PARENT_TABLE_2
       relationships:
         polymorphic:
           - local_attribute: ID
-            local_type_attribute: ''
             database: SNOWSHU_DEVELOPMENT
             schema: POLYMORPHIC_DATA
             relation: '(?i)^CHILD_TYPE_[0-9]_ITEMS$'

--- a/tests/assets/replica_test_config.yml
+++ b/tests/assets/replica_test_config.yml
@@ -90,4 +90,4 @@ source:
             database: SNOWSHU_DEVELOPMENT
             schema: POLYMORPHIC_DATA
             relation: '(?i)^CHILD_TYPE_[0-9]_ITEMS$'
-            remote_attribute: PARENT_ID
+            remote_attribute: PARENT_2_ID

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,17 +75,41 @@ class RelationTestHelper:
             materialization=mz.TABLE,
             attributes=[])
 
-        self.bidirectional_key_left = rand_string(10),
-        self.bidirectional_key_right = rand_string(8),
+        self.parent_relation_childid_type = Relation(
+            name='parent_relation_childid_type', **self.rand_relation_helper())
+        self.parent_relation_parentid = Relation(
+            name='parent_relation_parentid', **self.rand_relation_helper())
+        self.child_relation_type_1 = Relation(
+            name='child_type_1_records', **self.rand_relation_helper())
+        self.child_relation_type_2 = Relation(
+            name='child_type_2_records', **self.rand_relation_helper())
+        self.child_relation_type_3 = Relation(
+            name='child_type_3_records', **self.rand_relation_helper())
+
+        self.bidirectional_key_left = rand_string(10)
+        self.bidirectional_key_right = rand_string(8)
         self.directional_key = rand_string(15)
+        self.parentid_key = rand_string(15)
+        self.childid_key = rand_string(15)
+        self.childtype_key = rand_string(15)
 
         # update specifics
         self.view_relation.materialization = mz.VIEW
 
         for n in ('downstream_relation', 'upstream_relation', 'downstream_wildcard_relation_1', 'downstream_wildcard_relation_2',
                 'upstream_wildcard_relation_1', 'upstream_wildcard_relation_2'):
-            self.__dict__[n].attributes = [
-                Attribute(self.directional_key, dt.INTEGER)]
+            self.__dict__[n].attributes = [Attribute(self.directional_key, dt.INTEGER)]
+
+        for n in ('child_relation_type_1', 'child_relation_type_2', 'child_relation_type_3',):
+            self.__dict__[n].attributes = [Attribute(self.parentid_key, dt.VARCHAR), Attribute(self.childid_key, dt.VARCHAR)]
+
+        self.parent_relation_childid_type.attributes = [
+            Attribute(self.childid_key, dt.VARCHAR),
+            Attribute(self.childtype_key, dt.VARCHAR)
+        ]
+        self.parent_relation_parentid.attributes = [
+            Attribute(self.parentid_key, dt.VARCHAR)
+        ]
 
         self.birelation_right.attributes = [
             Attribute(self.bidirectional_key_right, dt.VARCHAR)]
@@ -93,7 +117,8 @@ class RelationTestHelper:
             Attribute(self.bidirectional_key_left, dt.VARCHAR)]
 
         for r in ('downstream_relation', 'upstream_relation', 'iso_relation', 'birelation_left', 'birelation_right', 'view_relation',
-                'downstream_wildcard_relation_1', 'downstream_wildcard_relation_2', 'upstream_wildcard_relation_1', 'upstream_wildcard_relation_2'):
+                'downstream_wildcard_relation_1', 'downstream_wildcard_relation_2', 'upstream_wildcard_relation_1', 'upstream_wildcard_relation_2',
+                'child_relation_type_1', 'child_relation_type_2', 'child_relation_type_3','parent_relation_childid_type','parent_relation_parentid'):
             self.__dict__[r].compiled_query = ''
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,7 @@ class RelationTestHelper:
         self.parentid_key = rand_string(15)
         self.childid_key = rand_string(15)
         self.childtype_key = rand_string(15)
+        self.child2override_key = rand_string(20)
 
         # update specifics
         self.view_relation.materialization = mz.VIEW

--- a/tests/conftest_modules/test_configuration.py
+++ b/tests/conftest_modules/test_configuration.py
@@ -121,7 +121,15 @@ CONFIGURATION = {
                             "database": "SNOWSHU_DEVELOPMENT",
                             "schema": "POLYMORPHIC_DATA",
                             "relation": "(?i)^CHILD_TYPE_[0-9]_ITEMS$",
-                            "remote_attribute": "ID"
+                            "remote_attribute": "ID",
+                            "local_type_overrides": [
+                                {
+                                    "database": "SNOWSHU_DEVELOPMENT",
+                                    "schema": "POLYMORPHIC_DATA",
+                                    "relation": "CHILD_TYPE_2_ITEMS",
+                                    "override_value": "type_2"
+                                }
+                            ]
                         }
                     ],
                 }
@@ -134,7 +142,6 @@ CONFIGURATION = {
                     "polymorphic": [
                         {
                             "local_attribute": "ID",
-                            "local_type_attribute": "",
                             "database": "SNOWSHU_DEVELOPMENT",
                             "schema": "POLYMORPHIC_DATA",
                             "relation": "(?i)^CHILD_TYPE_[0-9]_ITEMS$",

--- a/tests/conftest_modules/test_configuration.py
+++ b/tests/conftest_modules/test_configuration.py
@@ -133,12 +133,12 @@ CONFIGURATION = {
                 "relationships": {
                     "polymorphic": [
                         {
-                            "local_attribute": "PARENT_ID",
+                            "local_attribute": "ID",
                             "local_type_attribute": "",
                             "database": "SNOWSHU_DEVELOPMENT",
                             "schema": "POLYMORPHIC_DATA",
                             "relation": "(?i)^CHILD_TYPE_[0-9]_ITEMS$",
-                            "remote_attribute": "PARENT_ID"
+                            "remote_attribute": "PARENT_2_ID"
                         }
                     ],
                 }

--- a/tests/conftest_modules/test_configuration.py
+++ b/tests/conftest_modules/test_configuration.py
@@ -108,7 +108,41 @@ CONFIGURATION = {
                         "min_sample_size": 300
                     }
                 }
-            }
+            },
+            {
+                "database": "SNOWSHU_DEVELOPMENT",
+                "schema": "POLYMORPHIC_DATA",
+                "relation": "PARENT_TABLE",
+                "relationships": {
+                    "polymorphic": [
+                        {
+                            "local_attribute": "CHILD_ID",
+                            "local_type_attribute": "CHILD_TYPE",
+                            "database": "SNOWSHU_DEVELOPMENT",
+                            "schema": "POLYMORPHIC_DATA",
+                            "relation": "(?i)^CHILD_TYPE_[0-9]_ITEMS$",
+                            "remote_attribute": "ID"
+                        }
+                    ],
+                }
+            },
+            {
+                "database": "SNOWSHU_DEVELOPMENT",
+                "schema": "POLYMORPHIC_DATA",
+                "relation": "PARENT_TABLE_2",
+                "relationships": {
+                    "polymorphic": [
+                        {
+                            "local_attribute": "PARENT_ID",
+                            "local_type_attribute": "",
+                            "database": "SNOWSHU_DEVELOPMENT",
+                            "schema": "POLYMORPHIC_DATA",
+                            "relation": "(?i)^CHILD_TYPE_[0-9]_ITEMS$",
+                            "remote_attribute": "PARENT_ID"
+                        }
+                    ],
+                }
+            },
         ]
     },
     "target": {

--- a/tests/integration/snowflake/test_analyze.py
+++ b/tests/integration/snowflake/test_analyze.py
@@ -12,7 +12,7 @@ def test_analyze_unsampled(docker_flush):
 
     replica = ReplicaFactory()
 
-    config = os.path.join(PACKAGE_ROOT, "snowshu", "templates", "replica.yml")
+    config = os.path.join(PACKAGE_ROOT, "tests", "assets", "replica_test_config.yml")
     replica.load_config(config)
     result = replica.analyze(barf=False).split('\n')
     result.reverse()

--- a/tests/integration/snowflake/test_end_to_end.py
+++ b/tests/integration/snowflake/test_end_to_end.py
@@ -26,7 +26,7 @@ DOCKER_SPIN_UP_TIMEOUT = 15
 def end_to_end(docker_flush_session):
     runner = CliRunner()
     configuration_path = os.path.join(
-        PACKAGE_ROOT, 'snowshu', 'templates', 'replica.yml')
+        PACKAGE_ROOT, 'tests', 'assets', 'replica_test_config.yml')
     create_result=runner.invoke(cli, ('create', '--replica-file', configuration_path))
     if create_result.exit_code:
         print(create_result.exc_info)

--- a/tests/integration/snowflake/test_end_to_end.py
+++ b/tests/integration/snowflake/test_end_to_end.py
@@ -27,7 +27,7 @@ def end_to_end(docker_flush_session):
     runner = CliRunner()
     configuration_path = os.path.join(
         PACKAGE_ROOT, 'tests', 'assets', 'replica_test_config.yml')
-    create_result=runner.invoke(cli, ('create', '--replica-file', configuration_path))
+    create_result=runner.invoke(cli, ('create', '--replica-file', configuration_path, '--barf'))
     if create_result.exit_code:
         print(create_result.exc_info)
         raise create_result.exception
@@ -59,8 +59,9 @@ def test_reports_full_catalog_start(end_to_end):
 
 def test_finds_n_relations(end_to_end):
     result_lines= end_to_end
-    assert find_number_of_processed_relations(result_lines) == 11, \
-        "Number of found relations do not match the expected of 11 relations. Check database."
+    breakpoint()
+    assert find_number_of_processed_relations(result_lines) == 16, \
+        "Number of found relations do not match the expected of 16 relations. Check database."
 
 def test_replicates_order_items(end_to_end):
     result_lines = end_to_end

--- a/tests/unit/test_config_regex.py
+++ b/tests/unit/test_config_regex.py
@@ -32,7 +32,30 @@ MOCKED_CONFIG = dict(name='test',
                                                                                          database='snowno',
                                                                                          schema='THING',
                                                                                          relation='matches_in_directional')]
-                                                                       ))]),
+                                                                       )),
+                                                dict(database='(?i)^snow.*',
+                                                    schema='THING',
+                                                    relation='.*poly$',
+                                                    relationships=dict(polymorphic=[dict(local_attribute='child_id',
+                                                                                         local_type_attribute='child_type',
+                                                                                         remote_attribute='id',
+                                                                                         database='',
+                                                                                         schema='',
+                                                                                         relation='^poly_child_[0-9]_items$')
+                                                                                      ],
+                                                                       )),
+                                                dict(database='(?i)^snow.*',
+                                                    schema='THING',
+                                                    relation='.*poly2$',
+                                                    relationships=dict(polymorphic=[dict(local_attribute='id',
+                                                                                         local_type_attribute='',
+                                                                                         remote_attribute='parent_id',
+                                                                                         database='',
+                                                                                         schema='',
+                                                                                         relation='^poly_child_[0-9]_items$')
+                                                                                      ],
+                                                                       )),
+                                                ]),
                      target=dict(adapter='default'),
                      storage=dict(profile='default'))
 
@@ -49,7 +72,13 @@ MOCKED_CATALOG = (Relation('snowyes', 'thing', 'foo_suffix', mz.TABLE, []),
                            'matches_in_directional', mz.TABLE, []),
                   Relation('SNOWYES', 'thing',
                            'nevermatch_except_bidirectional', mz.TABLE, []),
-                  Relation('snowyes', 'thing', 'nevermatch_except_bidirectional', mz.TABLE, []),)
+                  Relation('snowyes', 'thing', 'nevermatch_except_bidirectional', mz.TABLE, []),
+                  Relation('snowyes', 'thing', 'parent_poly', mz.TABLE, []),
+                  Relation('snowyes', 'thing', 'parent_poly2', mz.TABLE, []),
+                  Relation('snowyes', 'thing', 'poly_child_1_items', mz.TABLE, []),
+                  Relation('snowyes', 'thing', 'poly_child_2_items', mz.TABLE, []),
+                  Relation('snowyes', 'thing', 'poly_child_3_items', mz.TABLE, []),
+                  )
 
 @pytest.mark.skip("TODO This test needs to be redone since the filtering is completed when the catalog is created, not during graph building")
 @mock.patch('snowshu.core.configuration_parser.ConfigurationParser._build_adapter_profile')
@@ -69,3 +98,11 @@ def test_included_and_excluded(target, adapter):
         assert MOCKED_CATALOG[4] not in matched_nodes.nodes
         assert MOCKED_CATALOG[5] not in matched_nodes.nodes
         assert MOCKED_CATALOG[6] in matched_nodes.nodes
+        assert MOCKED_CATALOG[7] in matched_nodes.nodes
+        assert MOCKED_CATALOG[8] in matched_nodes.nodes
+        # polymorphic matches
+        assert MOCKED_CATALOG[9] in matched_nodes.nodes
+        assert MOCKED_CATALOG[10] in matched_nodes.nodes
+        assert MOCKED_CATALOG[11] in matched_nodes.nodes
+        assert MOCKED_CATALOG[12] in matched_nodes.nodes
+        assert MOCKED_CATALOG[13] in matched_nodes.nodes

--- a/tests/unit/test_configuration_parser.py
+++ b/tests/unit/test_configuration_parser.py
@@ -40,6 +40,17 @@ def test_fills_empty_top_level_values(stub_configs):
     assert parsed.max_number_of_outliers==DEFAULT_MAX_NUMBER_OF_OUTLIERS
 
 
+def test_casing_polymorphic_overrides(stub_configs):
+    stub_configs = stub_configs()
+    mock_config_file=StringIO(yaml.dump(stub_configs))
+    parsed = ConfigurationParser().from_file_or_path(mock_config_file)
+    override_relation = [rel for rel in parsed.specified_relations if rel.relation_pattern == 'parent_table'][0]
+    overrides = override_relation.relationships.polymorphic[0].local_type_overrides
+    assert overrides
+    assert 'snowshu_development.polymorphic_data.child_type_2_items' in overrides
+    assert overrides['snowshu_development.polymorphic_data.child_type_2_items'] == 'type_2'
+
+
 def test_errors_on_missing_section(stub_configs):
     stub_configs = stub_configs()
     del stub_configs['source']

--- a/tests/unit/test_configuration_parser.py
+++ b/tests/unit/test_configuration_parser.py
@@ -18,9 +18,11 @@ from tests.common import rand_string
 def test_fills_in_empty_source_values(stub_replica_configuration):
     for rel in stub_replica_configuration.specified_relations:
         assert isinstance(rel.unsampled, bool)
+        assert isinstance(rel.relationships.directional, list)
         assert isinstance(rel.relationships.bidirectional, list)
+        assert isinstance(rel.relationships.polymorphic, list)
 
-        for direction in ('bidirectional', 'directional',):
+        for direction in ('bidirectional', 'directional', 'polymorphic'):
             assert getattr(rel.relationships, direction) is not None
 
 


### PR DESCRIPTION
This PR adds polymorphic relationship support. It supports both child tables that have a foreign key of a parent table as well as parent tables that have a foreign key and type of the child table.

The secondary attribute value matches are currently case insensitive. So `CHILD_ITEM` and `child_item` are considered to be of the same type.

Example relationship blocks:
``` yaml
    - database: SNOWSHU_DEVELOPMENT
      schema: POLYMORPHIC_DATA
      relation: PARENT_TABLE
      relationships:
        polymorphic:
          - local_attribute: CHILD_ID
            local_type_attribute: CHILD_TYPE
            database: ''
            schema: ''
            relation: '(?i)^CHILD_TYPE_[0-9]_ITEMS$'
            remote_attribute: ID
            local_type_overrides:
              - database: SNOWSHU_DEVELOPMENT
                schema: POLYMORPHIC_DATA
                relation: CHILD_TYPE_2_ITEMS
                override_value: type_2
    - database: SNOWSHU_DEVELOPMENT
      schema: POLYMORPHIC_DATA
      relation: PARENT_TABLE_2
      relationships:
        polymorphic:
          - local_attribute: ID
            database: SNOWSHU_DEVELOPMENT
            schema: POLYMORPHIC_DATA
            relation: '(?i)^CHILD_TYPE_[0-9]_ITEMS$'
            remote_attribute: PARENT_2_ID
```


If the child tables have foreign keys to the parent table, the `local_type_attribute` can be ignored since there is no secondary attribute to match records on.

Currently, the type matching defaults to `child_table_name` minus a trailing `'s'` if present (assuming plural table names, and singular types). So `child_items` would match type value `'child_item'`, whereas `other_children` will match on `'other_children'`. Note that this does not handle any other pluralizations (e.g. `'-es'`, `'-ies'`).

There is an override list that can be passed for any relations that don't follow a plural-singular pattern. Note that the `database`, `schema`, `relation` values cannot be regex and do not inherit values (like the `''` wildcard)
- [x] Add `local_type_overrides` options to relationships


The `include_outliers` functionality is not currently supported for polymorphic relationships and is ignored when set. A warning is logged in those cases.