### PR TITLE
Fix Failing Report Generation for Views

### DIFF
--- a/snowshu/core/printable_result.py
+++ b/snowshu/core/printable_result.py
@@ -36,15 +36,17 @@ def graph_to_result_list(graphs: nx.Graph) -> list:
             for relation in graph.nodes:
                 deps = len(nx.ancestors(graph, relation))
                 deps = " " if deps == 0 else str(deps)
-                target_sample_size = relation.population_size if \
-                    relation.unsampled or (relation.population_size < relation.sampling.size) \
-                    else relation.sampling.size
 
                 if isinstance(relation.population_size, str):
+                    target_sample_size = "N/A"
                     percent = "N/A"
                 elif int(relation.population_size) < 1:
                     percent = 0
+                    target_sample_size = relation.population_size
                 else:
+                    target_sample_size = relation.population_size if \
+                        relation.unsampled or (relation.population_size < relation.sampling.size) \
+                        else relation.sampling.size
                     percent = int(round(
                         100.0 * (relation.sample_size / target_sample_size)))
 

--- a/tests/unit/test_printable_result.py
+++ b/tests/unit/test_printable_result.py
@@ -1,19 +1,47 @@
-import pytest
-
+import snowshu.core.models.materializations as mz
 import snowshu.core.printable_result as pr
+from snowshu.samplings.samplings import DefaultSampling
 
 
-@pytest.mark.skip
+def generate_stub_complete_graph(stub_graph_set):
+    graph_list, _ = stub_graph_set
+    view_list = []
+    for graph in graph_list:
+        for rel in graph:
+            # set mocked sample
+            if rel.is_view:
+                rel.population_size = "N/A"
+                rel.sample_size = "N/A"
+                view_list.append(rel.dot_notation)
+            else:
+                rel.population_size = 1000
+                rel.sample_size = 10
+                # set and prepare sampling
+                rel.sampling = DefaultSampling()
+                rel.sampling.prepare(rel, None)
+
+    return graph_list, view_list
+
+
 def test_graph_to_list(stub_graph_set):
-    graphs, _ = stub_graph_set
-    for rel in graphs:
-        rel.populuation_size = 1000
-        rel.sample_size = 10
+    graph_list, view_list = generate_stub_complete_graph(stub_graph_set)
 
-    report = pr.graph_to_result_list(graphs)
+    report = pr.graph_to_result_list(graph_list)
 
     assert isinstance(report, list)
     for row in report:
         assert isinstance(row, pr.ReportRow)
-        assert row.percent == 10
-        assert row.percent_is_acceptable
+        if row.dot_notation in view_list:
+            assert row.population_size == 'N/A'
+            assert row.target_sample_size == 'N/A'
+            assert row.final_sample_size == 'N/A'
+            assert row.count_of_dependencies in (' ')
+            assert row.percent_to_target == 'N/A'
+            assert row.percent_is_acceptable == True
+        else:
+            assert row.population_size == 1000
+            assert row.target_sample_size == 1000
+            assert row.final_sample_size == 10
+            assert row.count_of_dependencies in (' ', '1')  # some relations had a dependency
+            assert row.percent_to_target == 1
+            assert row.percent_is_acceptable == False


### PR DESCRIPTION
When a view is included in the config, most of the size measurements and values are skipped and set as `"N/A"`, but there were some numerical comparisons before the `is_view` checks that failed when comparing strings and integers.

The existing skipped test has been updated to test the result for views and tables.