### PR TITLE
DATA-3883: the initial commit, handling the NaN values

### DIFF
--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -251,12 +251,20 @@ LIMIT {max_number_of_outliers})
                     remote_key).data_type.requires_quotes else str(val)
             try:
                 constraint_set = [
-                    quoted(val) for val in relation.data[remote_key].unique()]
+                    quoted(val) for val in relation.data[remote_key].dropna().unique()]
                 constraint_sql = ','.join(constraint_set)
+                if len(constraint_set) == 0:
+                    raise ValueError(f"The [{constraint_set}] constraint set is empty.")
             except KeyError as err:
                 logger.critical(
                     f'failed to build predicates for {relation.dot_notation}: '
                     f'remote key {remote_key} not in dataframe columns ({relation.data.columns})')
+                raise err
+            except ValueError as err:
+                logger.critical(
+                    f'failed to build predicates for {relation.dot_notation}: '
+                    f'the constraint set is empty, please validate the relation.'
+                )
                 raise err
 
         return f"{local_key} IN ({constraint_sql}) "

--- a/tests/integration/snowflake/test_snowflake_adapter.py
+++ b/tests/integration/snowflake/test_snowflake_adapter.py
@@ -3,6 +3,8 @@ from random import randrange
 import pytest
 import yaml
 
+
+
 import snowshu.core.models.materializations as mz
 from snowshu.adapters.source_adapters import BaseSourceAdapter
 from snowshu.adapters.source_adapters.snowflake_adapter import SnowflakeAdapter
@@ -314,7 +316,6 @@ def test_predicate_constraint_statement(sf_adapter):
             SAMPLE BERNOULLI (10)
         ))
         """)
-
 
 def test_check_count_and_query(sf_adapter):
     query = 'SELECT CHILD_ID from "SNOWSHU_DEVELOPMENT"."POLYMORPHIC_DATA"."PARENT_TABLE"'


### PR DESCRIPTION
In some cases, a column that needs to maintain referential integrity may have null values present when the field isn’t necessarily required. Currently, snowshu doesn’t support this case (and handles it awfully).