### PR TITLE
DATA-3883: handle the sf expressions list limit

### DIFF
--- a/tests/integration/snowflake/test_end_to_end.py
+++ b/tests/integration/snowflake/test_end_to_end.py
@@ -96,6 +96,7 @@ def test_replica_meta(end_to_end):
     # default for preserve case and max_outliers are set after parsing
     expected_config["preserve_case"] = DEFAULT_PRESERVE_CASE
     expected_config["source"]["max_number_of_outliers"] = DEFAULT_MAX_NUMBER_OF_OUTLIERS
+    expected_config["source"]["copy_views_as_tables"] = True
 
     query = conn.execute(query_string)
     results = query.fetchall()


### PR DESCRIPTION
a fix to handle the sf limit:

```
[33mRetrying SnowflakeAdapter.check_count_and_query: attempt 1 ended with: (snowflake.connector.errors.ProgrammingError) 001795 (42601): SQL compilation error: error line 6 at position 254
maximum number of expressions in a list exceeded, expected at most 16,384, got 20,185
[SQL: WITH __SNOWSHU__COUNTABLE__QUERY as (
SELECT
    *
FROM
...
```