### PR TITLE
bugfix/DATA-4976: Fix and tests

### DIFF
--- a/tests/unit/test_postgres_target_adapter.py
+++ b/tests/unit/test_postgres_target_adapter.py
@@ -93,13 +93,11 @@ def test_copy_replica_command():
     pg_adapter.stop_postgres = MagicMock()
     # Skip copy if only one container
     pg_adapter.container = MagicMock()
-    pg_adapter.container.exec_run = MagicMock()
     pg_adapter.copy_replica_data()
     pg_adapter.container.exec_run.assert_not_called()
 
     # Do copy if there are 2
     pg_adapter.passive_container = MagicMock()
-    pg_adapter.passive_container.exec_run = MagicMock()
     pg_adapter.copy_replica_data()
     pg_adapter.container.exec_run.assert_called_with(
         f"/bin/bash -c 'cp -af $PGDATA/* {DOCKER_REPLICA_MOUNT_FOLDER}'",

--- a/tests/unit/test_postgres_target_adapter.py
+++ b/tests/unit/test_postgres_target_adapter.py
@@ -90,8 +90,16 @@ def test_build_snowshu_envars():
 def test_copy_replica_command():
     """Test whether copy replica command is correctly called"""
     pg_adapter = PostgresAdapter(replica_metadata={})
+    pg_adapter.stop_postgres = MagicMock()
+    # Skip copy if only one container
     pg_adapter.container = MagicMock()
-    pg_adapter.container.exec_run = MagicMock(return_value=(0, ANY))
+    pg_adapter.container.exec_run = MagicMock(return_value=MagicMock())
+    pg_adapter.copy_replica_data()
+    pg_adapter.container.exec_run.assert_not_called()
+
+    # Do copy if there are 2
+    pg_adapter.passive_container = MagicMock()
+    pg_adapter.passive_container.exec_run = MagicMock(return_value=MagicMock())
     pg_adapter.copy_replica_data()
     pg_adapter.container.exec_run.assert_called_with(
         f"/bin/bash -c 'cp -af $PGDATA/* {DOCKER_REPLICA_MOUNT_FOLDER}'",

--- a/tests/unit/test_postgres_target_adapter.py
+++ b/tests/unit/test_postgres_target_adapter.py
@@ -93,13 +93,13 @@ def test_copy_replica_command():
     pg_adapter.stop_postgres = MagicMock()
     # Skip copy if only one container
     pg_adapter.container = MagicMock()
-    pg_adapter.container.exec_run = MagicMock(return_value=MagicMock())
+    pg_adapter.container.exec_run = MagicMock()
     pg_adapter.copy_replica_data()
     pg_adapter.container.exec_run.assert_not_called()
 
     # Do copy if there are 2
     pg_adapter.passive_container = MagicMock()
-    pg_adapter.passive_container.exec_run = MagicMock(return_value=MagicMock())
+    pg_adapter.passive_container.exec_run = MagicMock()
     pg_adapter.copy_replica_data()
     pg_adapter.container.exec_run.assert_called_with(
         f"/bin/bash -c 'cp -af $PGDATA/* {DOCKER_REPLICA_MOUNT_FOLDER}'",


### PR DESCRIPTION
Estimated root cause was postgres still runnning in the active container, while we were copying the pgdata off of it.
On small replicas pg is already not active at that time, but on larger replicas some queries might still be running, causing errors when pg is messing with the files (directory state is different at the start of cp and while it is running).

Validations: Multiarch run on a small replica. This is still not enough, since error pops up on a 2+ hr build replicas, which is infeasible to test (2hr per run, a lot of snowflake time). Proposed verification strategy is to roll this out and see if people continue to get errors.