### PR TITLE
Feature/data 5712

### DIFF
--- a/docs/source/user_documentation/replica_dot_yaml_file.rst
+++ b/docs/source/user_documentation/replica_dot_yaml_file.rst
@@ -91,8 +91,8 @@ Your initial replica file will look something like `this
          default:
            margin_of_error: 0.05
            confidence: 0.95
-          min_sample_size: 300
-          max_allowed_rows: 1500000
+           min_sample_size: 300
+           max_allowed_rows: 1500000
      - database: SNOWSHU_DEVELOPMENT
        schema: POLYMORPHIC_DATA
        relation: PARENT_TABLE
@@ -191,16 +191,31 @@ In our example, this portion of the source directive would be the overall source
      profile: default
      sampling: default
      include_outliers: True
-     copy_views_as_tables: True
+    copy_views_as_tables: True
 
 
 The components of the overall source settings, dissected:
 
 - **profile** (*Required*) is the name of the profile found in ``credentials.yml`` to execute with. In this example we are using a profile named "default".
-- **sampling** (*Required*) is the name of the sampling method to be used. Samplings combine both the number of records sampled and the way in which they are selected. Current sampling options are ``default`` (uses Bernoulli sampling and Cochran's sizing), or ``brute_force`` (Uses a fixed % and Bernoulli).
+- **sampling** (*Required*) is the name of the sampling method to be used. Samplings combine both
+the number of records sampled and the way in which they are selected. Current sampling options are ``default``
+(uses Bernoulli sampling and Cochran's sizing), or ``brute_force`` (Uses a fixed % and Bernoulli).
+
 - **copy_views_as_tables** (*Optional*) specifies if snowflake views should be recreated as views (Flase option) or loaded as tables (True option). False is option is more performant, but may not be compatible if snowflake view can not be ported to postgres
 - **include_outliers** (*Optional*) determines if SnowShu should look for records that do not respect specified relationships, and ensure they are included in the sample. Defaults to False. 
 - **max_number_of_outliers** (*Optional*) specifies the maximum number of outliers to include when they are found. This helps keep a bad relationship (such as an incorrect assumption on a trillion row table) from exploding the replica. Default is 100. 
+
+.. tip:: In the context of the ``brute_force`` sampling method, it is feasible to regulate the quantity of rows to be retrieved using the `max_allowed_rows` option.
+
+.. code-block:: yaml
+
+   ...
+   - database: SNOWSHU_DEVELOPMENT
+     schema: SOURCE_SYSTEM
+     relation:  'TABLE_(.*)'
+     sampling:
+      brute_force:
+        max_allowed_rows: 10
 
 
 .. relations in _replica.yml:
@@ -266,6 +281,12 @@ Specified relations look like this:
        schema: TESTS_DATA
        relation: DATA_TYPES
        unsampled: True
+     - database: SNOWSHU_DEVELOPMENT
+       schema: SOURCE_SYSTEM
+       relation:  'TABLE_(.*)'
+       sampling:
+        brute_force:
+          max_allowed_rows: 10
         
      - database: SNOWSHU_DEVELOPMENT
        schema: SOURCE_SYSTEM
@@ -300,7 +321,7 @@ Specified relations look like this:
          default:
            margin_of_error: 0.05
            confidence: 0.95
-          min_sample_size: 300
+           min_sample_size: 300
      - database: SNOWSHU_DEVELOPMENT
        schema: POLYMORPHIC_DATA
        relation: PARENT_TABLE

--- a/snowshu/samplings/samplings/brute_force_sampling.py
+++ b/snowshu/samplings/samplings/brute_force_sampling.py
@@ -18,7 +18,7 @@ class BruteForceSampling(BaseSampling):
     Args:
         probability: The % sample size desired in decimal format from 0.01 to 0.99. Default 10%.
         min_sample_size: The minimum number of records to retrieve from the population. Default 1000.
-    """ 
+    """
     size: int
 
     def __init__(self,
@@ -43,7 +43,9 @@ class BruteForceSampling(BaseSampling):
                 <snowshu.adapters.source_adapters.base_source_adapter.BaseSourceAdapter>` instance to
                 use for executing prepare queries.
         """
-        self.size = max(self.sample_size_method.size(relation.population_size),
-                        self.min_sample_size)
+        self.size = min(max(self.sample_size_method.size(
+            relation.population_size),
+            self.min_sample_size), self.max_allowed_rows)
+
         self.sample_method = BernoulliSampleMethod(self.size,
                                                    units='rows')

--- a/tests/unit/test_brute_force_sampling.py
+++ b/tests/unit/test_brute_force_sampling.py
@@ -1,0 +1,61 @@
+from unittest import mock
+import pytest
+
+from snowshu.samplings.samplings import BruteForceSampling
+
+
+@pytest.fixture()
+def mock_args():
+    mock_rel=mock.MagicMock()
+    mock_source_adapter=mock.MagicMock()
+    yield mock_rel,mock_source_adapter
+
+
+ONE_BILLION_ROWS=1e9
+ONE_HUNDRED_THOUSAND_ROWS=1e5
+def test_brute_force_sampling_stock(mock_args):
+    mock_args[0].population_size=ONE_BILLION_ROWS
+    brute_force=BruteForceSampling()
+    brute_force.prepare(*mock_args)
+
+    assert brute_force.sample_method.rows == 1000000
+
+def test_brute_force_sampling_fine(mock_args):
+    # GIVEN: mock_args - mock for snowshu.core.models.relation.Relation
+    #        2% rows to be sampled of ONE_HUNDRED_THOUSAND_ROWS
+    #        the min_sample_size is 3000
+    #        expectation - 1000000 rows to be sampled
+    brute_force=BruteForceSampling(probability = 0.02, min_sample_size = 3000)
+    mock_args[0].population_size=ONE_BILLION_ROWS
+    brute_force.prepare(*mock_args)
+    assert brute_force.sample_method.rows == 1000000
+
+def test_brute_force_sampling_min(mock_args):
+    # GIVEN: mock_args - mock for snowshu.core.models.relation.Relation
+    #        20% rows to be sampled of ONE_HUNDRED_THOUSAND_ROWS
+    #        the min_sample_size is 5000
+    #        expectation - 20000 rows to be sampled
+    brute_force=BruteForceSampling(probability = 0.2, min_sample_size = 20000)
+    mock_args[0].population_size=ONE_HUNDRED_THOUSAND_ROWS
+    brute_force.prepare(*mock_args)
+    assert brute_force.sample_method.rows == 20000
+
+def test_brute_force_sampling_override_min(mock_args):
+    # GIVEN: mock_args - mock for snowshu.core.models.relation.Relation
+    #        10% rows to be sampled of ONE_HUNDRED_THOUSAND_ROWS
+    #        the min_sample_size is 15000
+    #        expectation - 15000 rows to be sampled
+    brute_force=BruteForceSampling(probability = 0.1,  min_sample_size = 15000)
+    mock_args[0].population_size=ONE_HUNDRED_THOUSAND_ROWS
+    brute_force.prepare(*mock_args)
+    assert brute_force.sample_method.rows == 15000
+
+def test_brute_force_sampling_max(mock_args):
+    # GIVEN: mock_args - mock for snowshu.core.models.relation.Relation
+    #        20% rows to be sampled of ONE_HUNDRED_THOUSAND_ROWS
+    #        the max_allowed_rows is 100
+    #        expectation - 100 rows to be sampled
+    brute_force=BruteForceSampling(probability = 0.2, min_sample_size = 0.50, max_allowed_rows=100)
+    mock_args[0].population_size=ONE_HUNDRED_THOUSAND_ROWS
+    brute_force.prepare(*mock_args)
+    assert brute_force.sample_method.rows == 100

--- a/tests/unit/test_sampling_utils.py
+++ b/tests/unit/test_sampling_utils.py
@@ -1,6 +1,17 @@
+import pytest
 from snowshu.core.samplings.utils import get_sampling_from_partial
-from snowshu.samplings.samplings import DefaultSampling
+from snowshu.samplings.samplings import DefaultSampling, BruteForceSampling
 
 
-def test_finds_default():
-    assert isinstance(get_sampling_from_partial('default'),DefaultSampling)
+@pytest.mark.parametrize('sample_method, expected_sampling', [
+    ('default', DefaultSampling),
+    ('brute_force', BruteForceSampling)
+])
+def test_finds_bruite_force(sample_method, expected_sampling):
+    """
+        GIVEN: sample_method - the sampling literal
+               expected_instance - the expected sampling class
+    """
+    assert isinstance(get_sampling_from_partial(sample_method), expected_sampling), f"The {expected_sampling.__name__} " \
+                                                                                  f"test case failed."
+


### PR DESCRIPTION
Now, it is feasible to regulate the quantity of rows to be retrieved using the `max_allowed_rows` option
(i) only applicable for the brute_force sampling method

for more details please refer to the https://health-union.atlassian.net/browse/DATA-5712

Test results:
<img width="1734" alt="image" src="https://github.com/Health-Union/snowshu/assets/98582037/874bc40a-39c8-48d4-8ae1-49d4cd592a0d">
