### PR TITLE
Feat/data 3498 switch sampling queries

### DIFF
--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -532,13 +532,11 @@ LIMIT {max_number_of_outliers})
                 'Adapter.get_connection called before setting Adapter.credentials')
 
         logger.debug(f'Acquiring {self.CLASSNAME} connection...')
-        overrides = dict(       # noqa pylint: disable=redefined-outer-name
-            (k,
-             v) for (
-                k,
-                v) in dict(
-                database=database_override,
-                schema=schema_override).items() if v is not None)
+        overrides = {  # noqa pylint: disable=redefined-outer-name
+            'database': database_override,
+            'schema': schema_override
+        }
+        overrides = {k: v for k, v in overrides.items() if v is not None}
 
         engine = sqlalchemy.create_engine(
             self._build_conn_string(overrides), poolclass=NullPool)

--- a/snowshu/configs.py
+++ b/snowshu/configs.py
@@ -19,6 +19,7 @@ DOCKER_TARGET_PORT = 9999
 DOCKER_WORKING_DIR = Path('/app').as_posix()
 DOCKER_API_TIMEOUT = 600  # in seconds, default is 60 which causes issues
 POSTGRES_IMAGE = 'postgres:12'
+DEFAULT_TEMPORARY_DATABASE = 'SANDBOX'
 
 
 def _is_in_docker() -> bool:

--- a/snowshu/configs.py
+++ b/snowshu/configs.py
@@ -19,7 +19,7 @@ DOCKER_TARGET_PORT = 9999
 DOCKER_WORKING_DIR = Path('/app').as_posix()
 DOCKER_API_TIMEOUT = 600  # in seconds, default is 60 which causes issues
 POSTGRES_IMAGE = 'postgres:12'
-DEFAULT_TEMPORARY_DATABASE = 'SANDBOX'
+DEFAULT_TEMPORARY_DATABASE = 'SNOWSHU'
 
 
 def _is_in_docker() -> bool:

--- a/snowshu/core/graph_set_runner.py
+++ b/snowshu/core/graph_set_runner.py
@@ -4,7 +4,7 @@ import shutil
 import time
 import threading
 import concurrent.futures
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Tuple, Set, List
 import logging

--- a/snowshu/core/graph_set_runner.py
+++ b/snowshu/core/graph_set_runner.py
@@ -10,7 +10,7 @@ import logging
 
 import networkx as nx
 
-from snowshu.adapters.source_adapters.base_sql_adapter import BaseSQLAdapter
+from snowshu.adapters.base_sql_adapter import BaseSQLAdapter
 from snowshu.adapters.source_adapters.base_source_adapter import \
     BaseSourceAdapter
 from snowshu.adapters.target_adapters.base_target_adapter import \
@@ -216,7 +216,7 @@ class GraphSetRunner:
                         except Exception as exc:
                             raise SystemError(
                                 f'Failed to extract DDL statement: {relation.compiled_query}') from exc
-                        logger.info('Successfully extracted DDL statement for view ' 
+                        logger.info('Successfully extracted DDL statement for view '
                                     f'{executable.target_adapter.quoted_dot_notation(relation)}')
                     else:
                         source = f"{relation.temp_database}.{relation.schema}.{relation.name}"
@@ -241,18 +241,18 @@ class GraphSetRunner:
                         logger.info(
                             f'{relation.sample_size} records retrieved for relation {relation.dot_notation}.')
 
-                    logger.info(f'Inserting relation {executable.target_adapter.quoted_dot_notation(relation)}' 
+                    logger.info(f'Inserting relation {executable.target_adapter.quoted_dot_notation(relation)}'
                                 ' into target...')
                     try:
                         executable.target_adapter.create_and_load_relation(
                             relation)
                     except Exception as exc:
                         raise SystemError('Failed to load relation '
-                                          f'{executable.target_adapter.quoted_dot_notation(relation)} ' 
+                                          f'{executable.target_adapter.quoted_dot_notation(relation)} '
                                           f' into target: {exc}') from exc
 
-                    logger.info('Done replication of relation ' 
-                                f'{executable.target_adapter.quoted_dot_notation(relation)} ' 
+                    logger.info('Done replication of relation '
+                                f'{executable.target_adapter.quoted_dot_notation(relation)} '
                                 f' in {duration(start_time)}.')
                     relation.target_loaded = True
                 relation.source_extracted = True

--- a/snowshu/core/models/relation.py
+++ b/snowshu/core/models/relation.py
@@ -5,7 +5,8 @@ import re
 from sqlalchemy.types import JSON
 import pandas as pd
 
-from snowshu.configs import DEFAULT_MAX_NUMBER_OF_OUTLIERS
+from snowshu.configs import DEFAULT_MAX_NUMBER_OF_OUTLIERS,
+    DEFAULT_TEMPORARY_DATABASE
 from snowshu.core.models import materializations as mz
 from snowshu.core.models.attribute import Attribute
 from snowshu.core.utils import correct_case
@@ -29,6 +30,7 @@ class Relation:
     unsampled: bool = False
     include_outliers: bool = False
     max_number_of_outliers: int = DEFAULT_MAX_NUMBER_OF_OUTLIERS
+    temp_database: str = DEFAULT_TEMPORARY_DATABASE
 
     def __init__(self,  # noqa pylint: disable=too-many-arguments
                  database: str,

--- a/snowshu/core/models/relation.py
+++ b/snowshu/core/models/relation.py
@@ -5,8 +5,10 @@ import re
 from sqlalchemy.types import JSON
 import pandas as pd
 
-from snowshu.configs import DEFAULT_MAX_NUMBER_OF_OUTLIERS,
+from snowshu.configs import (
+    DEFAULT_MAX_NUMBER_OF_OUTLIERS,
     DEFAULT_TEMPORARY_DATABASE
+)
 from snowshu.core.models import materializations as mz
 from snowshu.core.models.attribute import Attribute
 from snowshu.core.utils import correct_case

--- a/snowshu/core/utils.py
+++ b/snowshu/core/utils.py
@@ -125,7 +125,7 @@ def remove_dangling_replica_containers() -> None:
             container.remove(force=True)
 
 
-def generate_unique_uuid_name(name: str) -> str:
+def generate_unique_uuid(is_upper: bool) -> str:
     """Generates a unique name based on name and randomly generated uuid."""
     _uuid = str(uuid.uuid4()).rsplit('-', maxsplit=1)[-1]
-    return "_".join([name, _uuid])
+    return _uuid.upper() if is_upper else _uuid

--- a/snowshu/core/utils.py
+++ b/snowshu/core/utils.py
@@ -125,7 +125,7 @@ def remove_dangling_replica_containers() -> None:
             container.remove(force=True)
 
 
-def generate_unique_uuid(is_upper: bool) -> str:
+def generate_unique_uuid(is_upper: bool = True) -> str:
     """Generates a unique name based on name and randomly generated uuid."""
     _uuid = str(uuid.uuid4()).rsplit('-', maxsplit=1)[-1]
     return _uuid.upper() if is_upper else _uuid


### PR DESCRIPTION
Tl;dr: Switch sampling queries, instead of querying sampled data we first create a transient table with sampled data and then fetch transient table to local memory. On top of that some code refactors.

Context:
The goal is to transition from storing temporary data in memory to storing it in Snowflake. 

During data extraction, Snowshu should utilize a previously created function to generate schemas and tables in Snowflake. After creating these schemas and tables, it should transfer data from the temporary tables into the relation.data attribute.

After processing the entire connected subgraph, the temporary schemas and tables in Snowflake should be cleaned up. 

The core part responsible for it is placed in ```graph_set_runner.py``` module.

On top of that there are some refactors making code easier to read and understand.

Test Plan:
If someone would like to test it, I'd recommend to install this package from source and later try to execute snowshu create function on one of snowflake repos eg. hu-dw-artifact, hu-dw-datawarehouse
