### PR TITLE
Feat/data 3499 switch sampling references

### DIFF
--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -388,7 +388,7 @@ LIMIT {max_number_of_outliers})
                                          remote_key: str,
                                          local_type: str,
                                          local_type_match_val: str = None) -> str:
-        predicate = self.predicate_constraint_statement(relation, analyze, local_key, remote_key)
+        predicate = SnowflakeAdapter().predicate_constraint_statement(relation, analyze, local_key, remote_key)
         if local_type_match_val:
             type_match_val = local_type_match_val
         else:

--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -381,8 +381,9 @@ LIMIT {max_number_of_outliers})
 
         return f"{local_key} IN ({constraint_sql}) "
 
+    # pylint: disable=too-many-arguments
     def polymorphic_constraint_statement(self,
-                                         relation: Relation,  # noqa pylint: disable=too-many-arguments
+                                         relation: Relation,
                                          analyze: bool,
                                          local_key: str,
                                          remote_key: str,

--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 from urllib.parse import quote
 
 import pandas as pd
@@ -388,7 +388,7 @@ LIMIT {max_number_of_outliers})
                                          remote_key: str,
                                          local_type: str,
                                          local_type_match_val: str = None) -> str:
-        predicate = SnowflakeAdapter.predicate_constraint_statement(relation, analyze, local_key, remote_key)
+        predicate = SnowflakeAdapter().predicate_constraint_statement(relation, analyze, local_key, remote_key)
         if local_type_match_val:
             type_match_val = local_type_match_val
         else:

--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -381,14 +381,14 @@ LIMIT {max_number_of_outliers})
 
         return f"{local_key} IN ({constraint_sql}) "
 
-    @staticmethod
-    def polymorphic_constraint_statement(relation: Relation,  # noqa pylint: disable=too-many-arguments
+    def polymorphic_constraint_statement(self,
+                                         relation: Relation,  # noqa pylint: disable=too-many-arguments
                                          analyze: bool,
                                          local_key: str,
                                          remote_key: str,
                                          local_type: str,
                                          local_type_match_val: str = None) -> str:
-        predicate = SnowflakeAdapter().predicate_constraint_statement(relation, analyze, local_key, remote_key)
+        predicate = self.predicate_constraint_statement(relation, analyze, local_key, remote_key)
         if local_type_match_val:
             type_match_val = local_type_match_val
         else:

--- a/snowshu/core/graph_set_runner.py
+++ b/snowshu/core/graph_set_runner.py
@@ -174,9 +174,9 @@ class GraphSetRunner:
             sorted_graphs = nx.algorithms.dag.topological_sort(executable.graph)
             for i, relation in enumerate(sorted_graphs, start=1):
 
-                unique_schema_name = "_".join([relation.schema, self.uuid])
+                relation.temp_schema = "_".join([relation.schema, self.uuid])
                 self._generate_schemas_if_necessary(
-                    executable.source_adapter, unique_schema_name, relation.temp_database
+                    executable.source_adapter, relation.temp_schema, relation.temp_database
                 )
 
                 relation.population_size = executable.source_adapter.scalar_query(
@@ -188,7 +188,6 @@ class GraphSetRunner:
                                           executable.source_adapter)
                 relation = RuntimeSourceCompiler.compile_queries_for_relation(
                     relation, executable.graph, executable.source_adapter, executable.analyze)
-
                 if executable.analyze:
                     if relation.is_view:
                         relation.population_size = "N/A"
@@ -223,17 +222,16 @@ class GraphSetRunner:
                         logger.info('Successfully extracted DDL statement for view '
                                     f'{executable.target_adapter.quoted_dot_notation(relation)}')
                     else:
-                        source = f"{relation.temp_database}.{relation.schema}.{relation.name}"
                         logger.info(
-                            f'Retrieving records from source {source}...')
+                            f'Retrieving records from source {relation.temp_dot_notation}...')
                         try:
                             executable.source_adapter.create_table(
                                 query=relation.compiled_query,
                                 name=relation.name,
-                                schema=unique_schema_name,
+                                schema=relation.temp_schema,
                                 database=relation.temp_database,
                             )
-                            fetch_query = f"SELECT * FROM {relation.temp_database}.{unique_schema_name}.{relation.name}"
+                            fetch_query = f"SELECT * FROM {relation.temp_dot_notation}"
                             relation.data = executable.source_adapter.check_count_and_query(
                                 fetch_query, relation.sampling.max_allowed_rows, relation.unsampled)
                         except Exception as exc:

--- a/snowshu/core/graph_set_runner.py
+++ b/snowshu/core/graph_set_runner.py
@@ -171,8 +171,8 @@ class GraphSetRunner:
         try:
             logger.debug(
                 f"Executing graph with {len(executable.graph)} relations in it...")
-            for i, relation in enumerate(
-                    nx.algorithms.dag.topological_sort(executable.graph)):
+            sorted_graphs = nx.algorithms.dag.topological_sort(executable.graph)
+            for i, relation in enumerate(sorted_graphs, start=1):
 
                 unique_schema_name = "_".join([relation.schema, self.uuid])
                 self._generate_schemas_if_necessary(
@@ -182,7 +182,7 @@ class GraphSetRunner:
                 relation.population_size = executable.source_adapter.scalar_query(
                     executable.source_adapter.population_count_statement(relation))
                 logger.info(f'Executing source query for relation {relation.dot_notation} '
-                            f'({i+1} of {len(executable.graph)} in graph)...')
+                            f'({i} of {len(executable.graph)} in graph)...')
 
                 relation.sampling.prepare(relation,
                                           executable.source_adapter)

--- a/snowshu/core/models/relation.py
+++ b/snowshu/core/models/relation.py
@@ -33,6 +33,7 @@ class Relation:
     include_outliers: bool = False
     max_number_of_outliers: int = DEFAULT_MAX_NUMBER_OF_OUTLIERS
     temp_database: str = DEFAULT_TEMPORARY_DATABASE
+    temp_schema: Optional[str] = None
 
     def __init__(self,  # noqa pylint: disable=too-many-arguments
                  database: str,
@@ -95,6 +96,18 @@ class Relation:
     @property
     def dot_notation(self) -> str:
         return f"{self.database}.{self.schema}.{self.name}"
+
+    @property
+    def temp_dot_notation(self) -> str:
+        missing: List[str] = []
+        if not self.temp_database:
+            missing.append("relation.temp_database")
+        if not self.temp_schema:
+            missing.append("relation.temp_schema")
+        if missing:
+            raise ValueError(
+                f"Cannot create temp dot notation. Missing {', '.join(missing)}")
+        return f"{self.temp_database}.{self.temp_schema}.{self.name}"
 
     @property
     def star(self) -> str:

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -163,10 +163,10 @@ def test_run_deps_polymorphic_idtype(stub_relation_set):
         f"({childid} IN ('1','4') AND LOWER({childtype}) = LOWER('CHILD_TYPE_3_RECORD'))"
     ]
 
-    mock = Mock()
-    mock.polymorphic_constraint_statement.side_effect = mock_polymorphic_constraint_statements
+    _mock = Mock()
+    _mock.polymorphic_constraint_statement.side_effect = mock_polymorphic_constraint_statements
 
-    with patch.object(adapter, 'polymorphic_constraint_statement', new=mock.polymorphic_constraint_statement):
+    with patch.object(adapter, 'polymorphic_constraint_statement', new=_mock.polymorphic_constraint_statement):
         parent = RuntimeSourceCompiler.compile_queries_for_relation(parent,dag,adapter,False)
 
     expected_query = f"""
@@ -203,14 +203,14 @@ def test_run_deps_polymorphic_parentid(stub_relation_set):
         f"({parentid} IN ('3','30'))"
     ]
 
-    mock = Mock()
-    mock.mock_predicate_constraint_statements.side_effect = mock_predicate_constraint_statements
+    _mock = Mock()
+    _mock.mock_predicate_constraint_statements.side_effect = mock_predicate_constraint_statements
 
     child1 = RuntimeSourceCompiler.compile_queries_for_relation(child1,dag,adapter,False)
     child2 = RuntimeSourceCompiler.compile_queries_for_relation(child2,dag,adapter,False)
     child3 = RuntimeSourceCompiler.compile_queries_for_relation(child3,dag,adapter,False)
 
-    with patch.object(adapter, 'predicate_constraint_statement', new=mock.mock_predicate_constraint_statements):
+    with patch.object(adapter, 'predicate_constraint_statement', new=_mock.mock_predicate_constraint_statements):
         parent = RuntimeSourceCompiler.compile_queries_for_relation(parent,dag,adapter,False)
 
     expected_query = f"""
@@ -239,10 +239,10 @@ def test_run_deps_directional(stub_relation_set):
     adapter=SnowflakeAdapter()
 
     mock_predicate_constraint_statements = ['id IN (1,2,3)']
-    mock = Mock()
-    mock.mock_predicate_constraint_statements.side_effect = mock_predicate_constraint_statements
+    _mock = Mock()
+    _mock.mock_predicate_constraint_statements.side_effect = mock_predicate_constraint_statements
 
-    with patch.object(adapter, 'predicate_constraint_statement', new=mock.mock_predicate_constraint_statements):
+    with patch.object(adapter, 'predicate_constraint_statement', new=_mock.mock_predicate_constraint_statements):
         upstream = RuntimeSourceCompiler.compile_queries_for_relation(upstream,dag,adapter,False)
         downstream = RuntimeSourceCompiler.compile_queries_for_relation(downstream,dag,adapter,False)
 
@@ -285,9 +285,9 @@ def test_run_deps_bidirectional_include_outliers(stub_relation_set):
     RuntimeSourceCompiler.compile_queries_for_relation(upstream,dag,adapter,False)
 
     mock_predicate_constraint_statements = ['id IN (1,2,3)']
-    mock = Mock()
-    mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
-    with patch.object(adapter, 'predicate_constraint_statement', new=mock.predicate_constraint_statement):
+    _mock = Mock()
+    _mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
+    with patch.object(adapter, 'predicate_constraint_statement', new=_mock.predicate_constraint_statement):
         RuntimeSourceCompiler.compile_queries_for_relation(downstream, dag, adapter, False)
 
     assert query_equalize(downstream.compiled_query)==query_equalize(f"""
@@ -351,9 +351,9 @@ def test_run_deps_bidirectional_exclude_outliers(stub_relation_set):
     RuntimeSourceCompiler.compile_queries_for_relation(upstream,dag,adapter,False)
 
     mock_predicate_constraint_statements = ['id IN (1,2,3)']
-    mock = Mock()
-    mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
-    with patch.object(adapter, 'predicate_constraint_statement', new=mock.predicate_constraint_statement):
+    _mock = Mock()
+    _mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
+    with patch.object(adapter, 'predicate_constraint_statement', new=_mock.predicate_constraint_statement):
         RuntimeSourceCompiler.compile_queries_for_relation(downstream,dag,adapter,False)
 
     assert query_equalize(downstream.compiled_query)==query_equalize(f"""
@@ -435,10 +435,10 @@ def test_run_deps_directional_line_graph():
         'col_b_a IN (1,2,3,4,5)',
         'col_c IN (\'val1\',\'val3\',\'val4\')'
     ]
-    mock = Mock()
-    mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
-    for relation in relations.values():
-        with patch.object(adapter, 'predicate_constraint_statement', new=mock.predicate_constraint_statement):
+    _mock = Mock()
+    _mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
+    with patch.object(adapter, 'predicate_constraint_statement', new=_mock.predicate_constraint_statement):
+        for relation in relations.values():
             RuntimeSourceCompiler.compile_queries_for_relation(relation, dag, adapter, False)
 
     assert (
@@ -554,10 +554,10 @@ def test_run_deps_bidirectional_line_graph():
         'col_b_a IN (1,2,3,4,5)',
         'col_c IN (\'val1\',\'val3\',\'val4\')'
     ]
-    mock = Mock()
-    mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
-    for relation in relations.values():
-        with patch.object(adapter, 'predicate_constraint_statement', new=mock.predicate_constraint_statement):
+    _mock = Mock()
+    _mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
+    with patch.object(adapter, 'predicate_constraint_statement', new=_mock.predicate_constraint_statement):
+        for relation in relations.values():
             RuntimeSourceCompiler.compile_queries_for_relation(relation, dag, adapter, False)
 
     assert (
@@ -667,10 +667,10 @@ def test_run_deps_directional_multi_deps():
         'col_c_a IN (1,2,3,4,5)',
         'col_c_b IN (\'val1\',\'val2\',\'val3\',\'val4\',\'val5\')'
     ]
-    mock = Mock()
-    mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
-    for relation in relations.values():
-        with patch.object(adapter, 'predicate_constraint_statement', new=mock.predicate_constraint_statement):
+    _mock = Mock()
+    _mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
+    with patch.object(adapter, 'predicate_constraint_statement', new=_mock.predicate_constraint_statement):
+        for relation in relations.values():
             RuntimeSourceCompiler.compile_queries_for_relation(relation, dag, adapter, False)
 
     assert (
@@ -734,84 +734,127 @@ def test_run_deps_bidirectional_multi_deps():
         a --bidir--> c <--bidir-- b
     """
     relation_helper = RelationTestHelper()
-    relation_a = Relation(name='rel_a', **relation_helper.rand_relation_helper())
-    relation_a.attributes = [Attribute('col_a',dt.INTEGER)]
-    relation_a.data = pd.DataFrame({"col_a": [1, 2, 3, 4, 5,]})
+    relations_data = {
+        "rel_a": {
+            "attributes": [Attribute("col_a", dt.INTEGER)],
+        },
+        "rel_b": {
+            "attributes": [Attribute("col_b", dt.VARCHAR)],
+        },
+        "rel_c": {
+            "attributes": [Attribute("col_c_a", dt.INTEGER), Attribute("col_c_b", dt.VARCHAR)],
+        },
+    }
 
-    relation_b = Relation(name='rel_b', **relation_helper.rand_relation_helper())
-    relation_b.attributes = [Attribute('col_b',dt.VARCHAR)]
-    relation_b.data = pd.DataFrame({"col_b": ["val1", "val2", "val3", "val4", "val5",],})
+    relations = {}
+    for name, data in relations_data.items():
+        relation = Relation(name=name, **relation_helper.rand_relation_helper())
+        relation.attributes = data["attributes"]
+        relation.mock_schema = "mock_schema"
+        relation = stub_out_sampling(relation)
+        relations[name] = relation
 
-    relation_c = Relation(name='rel_c', **relation_helper.rand_relation_helper())
-    relation_c.attributes = [Attribute('col_c_a',dt.INTEGER), Attribute('col_c_b', dt.VARCHAR)]
+    dag = nx.MultiDiGraph()
+    dag.add_edge(
+        relations["rel_a"],
+        relations["rel_c"],
+        direction="bidirectional",
+        remote_attribute="col_a",
+        local_attribute="col_c_a",
+    )
+    dag.add_edge(
+        relations["rel_b"],
+        relations["rel_c"],
+        direction="bidirectional",
+        remote_attribute="col_b",
+        local_attribute="col_c_b",
+    )
+    adapter = SnowflakeAdapter()
 
-    for relation in (relation_a, relation_b, relation_c,):
-        relation=stub_out_sampling(relation)
+    mock_predicate_constraint_statements = [
+        'col_c_a IN (1,2,3,4,5)',
+        'col_c_b IN (\'val1\',\'val2\',\'val3\',\'val4\',\'val5\')'
+    ]
+    _mock = Mock()
+    _mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
+    with patch.object(adapter, 'predicate_constraint_statement', new=_mock.predicate_constraint_statement):
+        for relation in relations.values():
+            RuntimeSourceCompiler.compile_queries_for_relation(relation, dag, adapter, False)
 
-    dag=nx.MultiDiGraph()
-    dag.add_edge(relation_a, relation_c, direction="bidirectional", remote_attribute="col_a", local_attribute="col_c_a")
-    dag.add_edge(relation_b, relation_c, direction="bidirectional", remote_attribute="col_b", local_attribute="col_c_b")
-    adapter=SnowflakeAdapter()
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_a, dag, adapter, False)
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_b, dag, adapter, False)
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_c, dag, adapter, False)
-    assert query_equalize(relation_a.compiled_query) == query_equalize(f"""
-        WITH {relation_a.scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
+    assert (
+        query_equalize(relations["rel_a"].compiled_query)
+        == query_equalize(
+            f"""
+        WITH {relations['rel_a'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
         SELECT
             *
         FROM
-            {adapter.quoted_dot_notation(relation_a)}
+            {adapter.quoted_dot_notation(relations['rel_a'])}
         WHERE
             col_a
         in (SELECT
                 col_c_a
             FROM
-                {adapter.quoted_dot_notation(relation_c)}) )
-        ,{relation_a.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
+                {adapter.quoted_dot_notation(relations['rel_c'])}) )
+        ,{relations['rel_a'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
             SELECT
                 *
             FROM
-                {relation_a.scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
+                {relations['rel_a'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
         )
         SELECT
             *
         FROM
-        {relation_a.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
-    """)
-    assert query_equalize(relation_b.compiled_query) == query_equalize(f"""
+        {relations['rel_a'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
+    """
+        )
+    )
+
+    assert (
+        query_equalize(relations["rel_b"].compiled_query)
+        == query_equalize(
+            f"""
         WITH
-        {relation_b.scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
+        {relations['rel_b'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
         SELECT
             *
         FROM
-        {adapter.quoted_dot_notation(relation_b)}
+        {adapter.quoted_dot_notation(relations['rel_b'])}
         WHERE
             col_b
         in (SELECT
                 col_c_b
             FROM
-                {adapter.quoted_dot_notation(relation_c)})
+                {adapter.quoted_dot_notation(relations['rel_c'])})
         )
-        ,{relation_b.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
+        ,{relations['rel_b'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
         SELECT
             *
         FROM
-        {relation_b.scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
+        {relations['rel_b'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
         )
         SELECT
             *
         FROM
-        {relation_b.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
-    """)
-    assert query_equalize(relation_c.compiled_query) == query_equalize(f"""
+        {relations['rel_b'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
+    """
+        )
+    )
+
+    assert (
+        query_equalize(relations["rel_c"].compiled_query)
+        == query_equalize(
+            f"""
             SELECT
                 *
-            FROM {adapter.quoted_dot_notation(relation_c)}
+            FROM {adapter.quoted_dot_notation(relations['rel_c'])}
             WHERE
                 col_c_a IN (1,2,3,4,5)
             AND
                 col_c_b IN ('val1','val2','val3','val4','val5')
-    """)
+    """
+        )
+    )
 
 
 def test_run_deps_mixed_multi_deps():
@@ -824,122 +867,145 @@ def test_run_deps_mixed_multi_deps():
              dir-> d   e
     """
     relation_helper = RelationTestHelper()
-    relation_a = Relation(name='rel_a', **relation_helper.rand_relation_helper())
-    relation_a.attributes = [Attribute('col_a_c',dt.INTEGER), Attribute('col_a_d',dt.VARCHAR)]
-    relation_a.data = pd.DataFrame(
-        {
-            "col_a_c": [1, 2, 3, 4, 5,],
-            "col_a_d": ["var_a_1", "var_a_2", "var_a_3", "var_a_1", "var_a_2"],
+    relations_data = {
+        "rel_a": {
+            "attributes": [
+                Attribute("col_a_c", dt.INTEGER),
+                Attribute("col_a_d", dt.VARCHAR)
+            ]
+        },
+        "rel_b": {
+            "attributes": [
+                Attribute("col_b_c", dt.VARCHAR)
+            ]
+        },
+        "rel_c": {
+            "attributes": [
+                Attribute("col_c_ae", dt.INTEGER),
+                Attribute("col_c_bd", dt.VARCHAR)
+            ]
+        },
+        "rel_d": {
+            "attributes": [
+                Attribute("col_d_a", dt.INTEGER),
+                Attribute("col_d_c", dt.INTEGER)
+            ]
+        },
+        "rel_e": {
+            "attributes": [
+                Attribute("col_e_c", dt.INTEGER)
+            ]
         }
-    )
-    relation_b = Relation(name='rel_b', **relation_helper.rand_relation_helper())
-    relation_b.attributes = [Attribute('col_b_c',dt.VARCHAR)]
-    relation_b.data = pd.DataFrame({"col_b_c": ["val1", "val2", "val3", "val4", "val5",],})
+    }
+    # Rest of the code...
 
-    relation_c = Relation(name='rel_c', **relation_helper.rand_relation_helper())
-    relation_c.attributes = [Attribute('col_c_ae',dt.INTEGER), Attribute('col_c_bd', dt.VARCHAR)]
-    relation_c.data = pd.DataFrame(
-        {
-            "col_c_ae": [1, 1, 2, 2, 5, 5, 5,],
-            "col_c_bd": ["val1", "val1", "val2", "val2", "val5", "val5", "val5",]
-        }
-    )
+    relations = {}
+    for name, data in relations_data.items():
+        relation = Relation(name=name, **relation_helper.rand_relation_helper())
+        relation.attributes = data["attributes"]
+        relation.mock_schema = "mock_schema"
+        relation = stub_out_sampling(relation)
+        relations[name] = relation
 
-    relation_d = Relation(name='rel_d', **relation_helper.rand_relation_helper())
-    relation_d.attributes = [Attribute('col_d_a',dt.INTEGER), Attribute('col_d_c',dt.INTEGER)]
+    dag = nx.MultiDiGraph()
+    dag.add_edge(relations["rel_a"], relations["rel_c"], direction="bidirectional", remote_attribute="col_a_c", local_attribute="col_c_ae")
+    dag.add_edge(relations["rel_a"], relations["rel_d"], direction="directional", remote_attribute="col_a_d", local_attribute="col_d_a")
+    dag.add_edge(relations["rel_b"], relations["rel_c"], direction="directional", remote_attribute="col_b_c", local_attribute="col_c_bd")
+    dag.add_edge(relations["rel_c"], relations["rel_d"], direction="bidirectional", remote_attribute="col_c_bd", local_attribute="col_d_c")
+    dag.add_edge(relations["rel_c"], relations["rel_e"], direction="directional", remote_attribute="col_c_ae", local_attribute="col_e_c")
 
-    relation_e = Relation(name='rel_e', **relation_helper.rand_relation_helper())
-    relation_e.attributes = [Attribute('col_e_c',dt.INTEGER)]
+    adapter = SnowflakeAdapter()
+    mock_predicate_constraint_statements = [
+        'col_c_ae IN (1,2,3,4,5)',
+        'col_c_bd IN (\'val1\',\'val2\',\'val3\',\'val4\',\'val5\')',
+        'col_d_a IN (\'var_a_1\',\'var_a_2\',\'var_a_3\')',
+        'col_d_c IN (\'val1\',\'val2\',\'val5\')',
+        'col_e_c IN (1,2,5)'
+    ]
+    _mock = Mock()
+    _mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
+    with patch.object(adapter, 'predicate_constraint_statement', new=_mock.predicate_constraint_statement):
+        for relation in relations.values():
+            RuntimeSourceCompiler.compile_queries_for_relation(relation, dag, adapter, False)
 
-    for relation in (relation_a, relation_b, relation_c, relation_d, relation_e,):
-        relation=stub_out_sampling(relation)
-
-    dag=nx.MultiDiGraph()
-    dag.add_edge(relation_a, relation_c, direction="bidirectional", remote_attribute="col_a_c", local_attribute="col_c_ae")
-    dag.add_edge(relation_a, relation_d, direction="directional", remote_attribute="col_a_d", local_attribute="col_d_a")
-    dag.add_edge(relation_b, relation_c, direction="directional", remote_attribute="col_b_c", local_attribute="col_c_bd")
-    dag.add_edge(relation_c, relation_d, direction="bidirectional", remote_attribute="col_c_bd", local_attribute="col_d_c")
-    dag.add_edge(relation_c, relation_e, direction="directional", remote_attribute="col_c_ae", local_attribute="col_e_c")
-    adapter=SnowflakeAdapter()
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_a, dag, adapter, False)
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_b, dag, adapter, False)
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_c, dag, adapter, False)
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_d, dag, adapter, False)
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_e, dag, adapter, False)
-    assert query_equalize(relation_a.compiled_query) == query_equalize(f"""
-        WITH {relation_a.scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
+    assert query_equalize(relations['rel_a'].compiled_query) == query_equalize(f"""
+        WITH {relations['rel_a'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
         SELECT
             *
         FROM
-            {adapter.quoted_dot_notation(relation_a)}
+            {adapter.quoted_dot_notation(relations['rel_a'])}
         WHERE
             col_a_c
         in (SELECT
                 col_c_ae
             FROM
-                {adapter.quoted_dot_notation(relation_c)}) )
-        ,{relation_a.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
+                {adapter.quoted_dot_notation(relations['rel_c'])}) )
+        ,{relations['rel_a'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
             SELECT
                 *
             FROM
-                {relation_a.scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
+                {relations['rel_a'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
         )
         SELECT
             *
         FROM
-        {relation_a.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
+        {relations['rel_a'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
     """)
-    assert query_equalize(relation_b.compiled_query) == query_equalize(f"""
+
+    assert query_equalize(relations['rel_b'].compiled_query) == query_equalize(f"""
         SELECT
             *
         FROM
-            {adapter.quoted_dot_notation(relation_b)}
+            {adapter.quoted_dot_notation(relations['rel_b'])}
         SAMPLE BERNOULLI (1500 ROWS)
     """)
-    assert query_equalize(relation_c.compiled_query) == query_equalize(f"""
+
+    assert query_equalize(relations['rel_c'].compiled_query) == query_equalize(f"""
         SELECT
             *
         FROM
-            {adapter.quoted_dot_notation(relation_c)}
+            {adapter.quoted_dot_notation(relations['rel_c'])}
         WHERE
             col_c_bd
         in (SELECT
                 col_d_c
             FROM
-                {adapter.quoted_dot_notation(relation_d)})
+                {adapter.quoted_dot_notation(relations['rel_d'])})
         AND
             col_c_ae IN (1,2,3,4,5)
         AND
             col_c_bd IN ('val1','val2','val3','val4','val5')
     """)
-    assert query_equalize(relation_d.compiled_query) == query_equalize(f"""
+
+    assert query_equalize(relations['rel_d'].compiled_query) == query_equalize(f"""
         SELECT
             *
         FROM
-            {adapter.quoted_dot_notation(relation_d)}
+            {adapter.quoted_dot_notation(relations['rel_d'])}
         WHERE
             col_d_a IN ('var_a_1','var_a_2','var_a_3')
         AND
             col_d_c IN ('val1','val2','val5')
     """)
-    assert query_equalize(relation_e.compiled_query) == query_equalize(f"""
+
+    assert query_equalize(relations['rel_e'].compiled_query) == query_equalize(f"""
         WITH
-        {relation_e.scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
+        {relations['rel_e'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
         SELECT
             *
         FROM
-        {adapter.quoted_dot_notation(relation_e)}
+        {adapter.quoted_dot_notation(relations['rel_e'])}
         WHERE
             col_e_c IN (1,2,5)
         )
-        ,{relation_e.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
+        ,{relations['rel_e'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
         SELECT
             *
         FROM
-        {relation_e.scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
+        {relations['rel_e'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
         )
         SELECT
             *
         FROM
-        {relation_e.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
+        {relations['rel_e'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
     """)

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -393,77 +393,118 @@ def test_run_deps_directional_line_graph():
         a --dir--> b --dir--> c
     """
     relation_helper = RelationTestHelper()
-    relation_a = Relation(name='rel_a', **relation_helper.rand_relation_helper())
-    relation_a.attributes = [Attribute('col_a',dt.INTEGER)]
-    relation_a.data = pd.DataFrame({"col_a": [1, 2, 3, 4, 5,]})
+    relations_data = {
+        "rel_a": {
+            "attributes": [Attribute("col_a", dt.INTEGER)],
+        },
+        "rel_b": {
+            "attributes": [
+                Attribute("col_b_a", dt.INTEGER),
+                Attribute("col_b_c", dt.VARCHAR),
+            ],
+        },
+        "rel_c": {"attributes": [Attribute("col_c", dt.VARCHAR)], "data": {}},
+    }
 
-    relation_b = Relation(name='rel_b', **relation_helper.rand_relation_helper())
-    relation_b.attributes = [Attribute('col_b_a',dt.INTEGER), Attribute('col_b_c', dt.VARCHAR)]
-    relation_b.data = pd.DataFrame({
-        "col_b_a": [1, 3, 4, 4,],
-        "col_b_c": ["val1", "val3", "val4", "val4",],
-    })
+    relations = {}
+    for name, data in relations_data.items():
+        relation = Relation(name=name, **relation_helper.rand_relation_helper())
+        relation.attributes = data["attributes"]
+        relation = stub_out_sampling(relation)
+        relation.temp_schema = "mock_schema"
+        relations[name] = relation
 
-    relation_c = Relation(name='rel_c', **relation_helper.rand_relation_helper())
-    relation_c.attributes = [Attribute('col_c',dt.VARCHAR)]
+    dag = nx.MultiDiGraph()
+    dag.add_edge(
+        relations["rel_a"],
+        relations["rel_b"],
+        direction="directional",
+        remote_attribute="col_a",
+        local_attribute="col_b_a",
+    )
+    dag.add_edge(
+        relations["rel_b"],
+        relations["rel_c"],
+        direction="directional",
+        remote_attribute="col_b_c",
+        local_attribute="col_c",
+    )
+    adapter = SnowflakeAdapter()
 
-    for relation in (relation_a, relation_b, relation_c,):
-        relation=stub_out_sampling(relation)
+    mock_predicate_constraint_statements = [
+        'col_b_a IN (1,2,3,4,5)',
+        'col_c IN (\'val1\',\'val3\',\'val4\')'
+    ]
+    mock = Mock()
+    mock.predicate_constraint_statement.side_effect = mock_predicate_constraint_statements
+    for relation in relations.values():
+        with patch.object(adapter, 'predicate_constraint_statement', new=mock.predicate_constraint_statement):
+            RuntimeSourceCompiler.compile_queries_for_relation(relation, dag, adapter, False)
 
-    dag=nx.MultiDiGraph()
-    dag.add_edge(relation_a, relation_b, direction="directional", remote_attribute="col_a", local_attribute="col_b_a")
-    dag.add_edge(relation_b, relation_c, direction="directional", remote_attribute="col_b_c", local_attribute="col_c")
-    adapter=SnowflakeAdapter()
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_a, dag, adapter, False)
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_b, dag, adapter, False)
-    RuntimeSourceCompiler.compile_queries_for_relation(relation_c, dag, adapter, False)
-    assert query_equalize(relation_a.compiled_query) == query_equalize(f"""
+    assert (
+        query_equalize(relations["rel_a"].compiled_query)
+        == query_equalize(
+            f"""
         SELECT
             *
         FROM
-            {adapter.quoted_dot_notation(relation_a)}
+            {adapter.quoted_dot_notation(relations['rel_a'])}
         SAMPLE BERNOULLI (1500 ROWS)
-    """)
-    assert query_equalize(relation_b.compiled_query) == query_equalize(f"""
+    """
+        )
+    )
+
+    assert (
+        query_equalize(relations["rel_b"].compiled_query)
+        == query_equalize(
+            f"""
         WITH
-        {relation_b.scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
+        {relations['rel_b'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
         SELECT
             *
         FROM
-        {adapter.quoted_dot_notation(relation_b)}
+        {adapter.quoted_dot_notation(relations['rel_b'])}
         WHERE col_b_a IN (1,2,3,4,5)
         )
-        ,{relation_b.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
+        ,{relations['rel_b'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
         SELECT
             *
         FROM
-        {relation_b.scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
+        {relations['rel_b'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
         )
         SELECT
             *
         FROM
-        {relation_b.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
-    """)
-    assert query_equalize(relation_c.compiled_query) == query_equalize(f"""
+        {relations['rel_b'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
+    """
+        )
+    )
+
+    assert (
+        query_equalize(relations["rel_c"].compiled_query)
+        == query_equalize(
+            f"""
         WITH
-        {relation_c.scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
+        {relations['rel_c'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} AS (
         SELECT
             *
         FROM
-        {adapter.quoted_dot_notation(relation_c)}
+        {adapter.quoted_dot_notation(relations['rel_c'])}
         WHERE col_c IN ('val1','val3','val4')
         )
-        ,{relation_c.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
+        ,{relations['rel_c'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')} AS (
         SELECT
             *
         FROM
-        {relation_c.scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
+        {relations['rel_c'].scoped_cte('SNOWSHU_FINAL_SAMPLE')} SAMPLE BERNOULLI (1500 ROWS)
         )
         SELECT
             *
         FROM
-        {relation_c.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
-    """)
+        {relations['rel_c'].scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
+    """
+        )
+    )
 
 
 def test_run_deps_bidirectional_line_graph():
@@ -487,6 +528,7 @@ def test_run_deps_bidirectional_line_graph():
 
     for relation in (relation_a, relation_b, relation_c,):
         relation=stub_out_sampling(relation)
+        relation.temp_schema = 'mock_schema'
 
     dag=nx.MultiDiGraph()
     dag.add_edge(relation_a, relation_b, direction="bidirectional", remote_attribute="col_a", local_attribute="col_b_a")

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -84,7 +84,7 @@ def test_sample_statement():
     assert query_equalize(sample) == query_equalize(f"""
 SELECT
     *
-FROM 
+FROM
     {DATABASE}.{SCHEMA}.{TABLE}
     SAMPLE BERNOULLI (10)
 """)
@@ -102,21 +102,21 @@ def test_directional_statement():
     relation.core_query = f"""
 SELECT
     *
-FROM 
+FROM
     {DATABASE}.{SCHEMA}.{TABLE}
     SAMPLE BERNOULLI (10)
 """
     statement = sf.predicate_constraint_statement(
         relation, True, LOCAL_KEY, REMOTE_KEY)
     assert query_equalize(statement) == query_equalize(f"""
-{LOCAL_KEY} IN 
-    ( SELECT  
+{LOCAL_KEY} IN
+    ( SELECT
         {REMOTE_KEY}
       AS {LOCAL_KEY}
     FROM (
 SELECT
     *
-FROM 
+FROM
     {DATABASE}.{SCHEMA}.{TABLE}
     SAMPLE BERNOULLI (10)
 ))
@@ -178,72 +178,46 @@ FROM
     {relmock.scoped_cte('SNOWSHU_FINAL_SAMPLE')}
 SAMPLE BERNOULLI (50)
 )
-SELECT 
+SELECT
     *
-FROM 
+FROM
     {relmock.scoped_cte('SNOWSHU_DIRECTIONAL_SAMPLE')}
 """)
 
 
-def test_predicate_constraint_statement_null_values():
-    # GIVEN: a dataframe containing NULL entries in the REMOTE_KEY column
-    # APPLY: predicate_constraint_statement function
-    # EXPECTATION: null values  in the REMOTE_KEY are filtered out
+@mock.patch('snowshu.adapters.source_adapters.snowflake_adapter.SnowflakeAdapter._safe_query')
+@mock.patch('snowshu.core.models.relation.Relation')
+def test_predicate_constraint_statement_analyze_false_non_empty_constraint_set(mock_relation, mock_query):
+    """ Given non empty constraint set and analyze=False we expect a predicate constraint statement """
     sf = SnowflakeAdapter()
-    DATABASE, SCHEMA, TABLE_NAME = "SNOWSHU_DEVELOPMENT", "POLYMORPHIC_DATA", "PARENT_TABLE"
-    LOCAL_KEY, REMOTE_KEY = "ID", "CHILD_ID"
-
-    relation = Relation(database=DATABASE,
-                        schema=SCHEMA,
-                        name=TABLE_NAME,
-                        materialization=TABLE,
-                        attributes=[
-                            Attribute(REMOTE_KEY, data_types.NUMERIC)
-                        ])
-    CHILD_IDS = [1.0, 2.0, None]
-    EXPECTED_IDS = list(map(str, (filter(lambda x: x, CHILD_IDS))))
-    relation.data = DataFrame({"CHILD_ID": CHILD_IDS}, )
-
-    expected_statement = f"{LOCAL_KEY} IN ({','.join(EXPECTED_IDS)})"
-    statement = sf.predicate_constraint_statement(relation, False, LOCAL_KEY, REMOTE_KEY)
-
-    assert query_equalize(statement) == query_equalize(expected_statement)
+    mock_relation.temp_dot_notation = 'mock_dot_notation'
+    mock_query.return_value = DataFrame(['1', '2', '3'])
+    result = sf.predicate_constraint_statement(mock_relation, False, 'local_key', 'remote_key')
+    assert query_equalize(result) == query_equalize("local_key IN ('1','2','3') ")
 
 
-predicate_constraint_statement_outputs_to_check = [
-    ('No exceptions & no NaN values', [1.0, 2.0], does_not_raise()),
-    ('No exceptions & several NaN values', [1.0, None, 2.0, None], does_not_raise()),
-    ('ValueError exceptions & several NaN values', [None, None], pytest.raises(ValueError))
-]
-
-
-@pytest.mark.parametrize('test_name, child_ids, expectation',
-                         predicate_constraint_statement_outputs_to_check,
-                         ids=[i[0] for i in predicate_constraint_statement_outputs_to_check])
-def test_predicate_constraint_statement_null_values_exception(test_name, child_ids, expectation):
-    # GIVEN: a dataframe containing NULL entries in the REMOTE_KEY column
-    # APPLY: predicate_constraint_statement function
-    # EXPECTATION: null values  in the REMOTE_KEY are filtered out
+@mock.patch('snowshu.adapters.source_adapters.snowflake_adapter.SnowflakeAdapter._safe_query')
+@mock.patch('snowshu.core.models.relation.Relation')
+def test_predicate_constraint_statement_analyze_false_empty_constraint_set(mock_relation, mock_query):
+    """
+    Given empty constraint set and analyze=False we expect a predicate constraint statement
+    with a ValueError raised
+    """
     sf = SnowflakeAdapter()
-    DATABASE, SCHEMA, TABLE_NAME = "SNOWSHU_DEVELOPMENT", "POLYMORPHIC_DATA", "PARENT_TABLE"
-    LOCAL_KEY, REMOTE_KEY = "ID", "CHILD_ID"
+    mock_relation.temp_dot_notation = 'mock_dot_notation'
+    mock_query.return_value = DataFrame([])
+    with pytest.raises(ValueError, match=r"The constraint set for remote key remote_key in mock_dot_notation is empty."):
+        sf.predicate_constraint_statement(mock_relation, False, 'local_key', 'remote_key')
 
-    relation = Relation(database=DATABASE,
-                        schema=SCHEMA,
-                        name=TABLE_NAME,
-                        materialization=TABLE,
-                        attributes=[
-                            Attribute(REMOTE_KEY, data_types.NUMERIC)
-                        ])
 
-    EXPECTED_IDS = list(map(str, (filter(lambda x: x, child_ids))))
-    relation.data = DataFrame({"CHILD_ID": child_ids}, )
-
-    expected_statement = f"{LOCAL_KEY} IN ({','.join(EXPECTED_IDS)})"
-
-    with expectation:
-        statement = sf.predicate_constraint_statement(relation, False, LOCAL_KEY, REMOTE_KEY)
-        assert query_equalize(statement) == query_equalize(expected_statement)
+@mock.patch('snowshu.adapters.source_adapters.snowflake_adapter.SnowflakeAdapter._safe_query')
+@mock.patch('snowshu.core.models.relation.Relation')
+def test_predicate_constraint_statement_analyze_false_key_error(mock_relation, mock_safe_query):
+    sf = SnowflakeAdapter()
+    mock_relation.temp_dot_notation = 'mock_dot_notation'
+    mock_safe_query.side_effect = KeyError()
+    with pytest.raises(KeyError, match=r"Remote key remote_key not found in mock_dot_notation table."):
+        sf.predicate_constraint_statement(mock_relation, False, 'local_key', 'remote_key')
 
 
 def test_retry_count_query():

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -191,9 +191,9 @@ def test_predicate_constraint_statement_analyze_false_non_empty_constraint_set(m
     """ Given non empty constraint set and analyze=False we expect a predicate constraint statement """
     sf = SnowflakeAdapter()
     mock_relation.temp_dot_notation = 'mock_dot_notation'
-    mock_query.return_value = DataFrame(['1', '2', '3'])
+    mock_query.return_value = DataFrame(['1, 2, 3'])
     result = sf.predicate_constraint_statement(mock_relation, False, 'local_key', 'remote_key')
-    assert query_equalize(result) == query_equalize("local_key IN ('1','2','3') ")
+    assert query_equalize(result) == query_equalize("local_key IN (1, 2, 3) ")
 
 
 @mock.patch('snowshu.adapters.source_adapters.snowflake_adapter.SnowflakeAdapter._safe_query')
@@ -201,12 +201,12 @@ def test_predicate_constraint_statement_analyze_false_non_empty_constraint_set(m
 def test_predicate_constraint_statement_analyze_false_empty_constraint_set(mock_relation, mock_query):
     """
     Given empty constraint set and analyze=False we expect a predicate constraint statement
-    with a ValueError raised
+    with a IndexError raised
     """
     sf = SnowflakeAdapter()
     mock_relation.temp_dot_notation = 'mock_dot_notation'
     mock_query.return_value = DataFrame([])
-    with pytest.raises(ValueError, match=r"The constraint set for remote key remote_key in mock_dot_notation is empty."):
+    with pytest.raises(IndexError, match=f"Failed to build predicates: index 0 is out of bounds for axis 0 with size 0"):
         sf.predicate_constraint_statement(mock_relation, False, 'local_key', 'remote_key')
 
 


### PR DESCRIPTION
The main goal of this PR is to swich compilation of predicate_constraint_statement in snowflake instead of relation.data. On top of that it required a series of refactors to make it possible.

This Change:

- Refactor of predicate_constraint_statement and polymorphic_constraint_statement to make it work on Snowflake, not locally
- Refactor graph_set_runner and Relation to contain temp_schema name
- Refactor test_compiler.py so it doesn't rely on downstream methods
- Refactor test_snowflake_adapter.py to adjust to changes

Test Plan:
To test it, I'd recommend to run creation of snowshu replica in hu-dw-warehouse, including one general_relation and 3 different specified_relations (directional, bidirectional, polymorphic). Regarding massive amount of refactor changes in test_compiler.py, I'd recommend to check just 2-3 tests - the changes are similar in every test so it's more to understand whether suggested approach is acceptable.
