### PR TITLE
Hotfix/snowflake adapter missing credentials

### DIFF
--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -348,6 +348,7 @@ LIMIT {max_number_of_outliers})
                 f"FROM ("
                 f"    SELECT DISTINCT {remote_key} "
                 f"    FROM {relation.temp_dot_notation} "
+                f"    WHERE {remote_key} NOT LIKE '%''%' "
                 f"    LIMIT {SnowflakeAdapter.SNOWFLAKE_MAX_NUMBER_EXPR}"
                 f") AS subquery"
             )

--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -344,7 +344,7 @@ LIMIT {max_number_of_outliers})
                 return f"{local_key} IN ( SELECT {remote_key} AS {local_key} FROM ({relation.core_query}))"
 
             constraint_query = (
-                f"SELECT LISTAGG('''' || {remote_key}::VARCHAR || '''', ',') "
+                f"SELECT LISTAGG('''' || REPLACE({remote_key}::VARCHAR, '''', '') || '''', ',') "
                 f"FROM ("
                 f"    SELECT DISTINCT {remote_key} "
                 f"    FROM {relation.temp_dot_notation} "
@@ -391,7 +391,7 @@ LIMIT {max_number_of_outliers})
                                          remote_key: str,
                                          local_type: str,
                                          local_type_match_val: str = None) -> str:
-        predicate = SnowflakeAdapter().predicate_constraint_statement(relation, analyze, local_key, remote_key)
+        predicate = self.predicate_constraint_statement(relation, analyze, local_key, remote_key)
         if local_type_match_val:
             type_match_val = local_type_match_val
         else:

--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -344,7 +344,7 @@ LIMIT {max_number_of_outliers})
                 return f"{local_key} IN ( SELECT {remote_key} AS {local_key} FROM ({relation.core_query}))"
 
             constraint_query = (
-                f"SELECT LISTAGG('''' || REPLACE({remote_key}::VARCHAR, '''', '') || '''', ',') "
+                f"SELECT LISTAGG('''' || {remote_key}::VARCHAR || '''', ',') "
                 f"FROM ("
                 f"    SELECT DISTINCT {remote_key} "
                 f"    FROM {relation.temp_dot_notation} "


### PR DESCRIPTION
It's a hotfix to issue with _polymorphic_constraint_statement_, related to this: [https://us-east-1.console.aws.amazon.com/codesuite/codebuild/251286366697/projects/dev-snowsh[…]45e616-c83f-4800-8357-fe4144e838c0/?region=us-east-1](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/251286366697/projects/dev-snowshu-replica-builder-build-develop/build/dev-snowshu-replica-builder-build-develop%3A4745e616-c83f-4800-8357-fe4144e838c0/?region=us-east-1). It's in warehose_dev account, where in logs one need to look for '_credentials'. 