### PR TITLE
Bugfix/data 6671 failed bidirectional relationship

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ apt-get install -y --reinstall build-essential && \
 apt-get install -y gcc && \
 apt-get install -y vim nano htop screen && \
 echo "export PYTHONPATH=${PWD}:$PYTHONPATH" >> /root/.bashrc && \
-pip3 install -r requirements/dev.txt && \
-pip3 install .
+pip3 install uv \
+uv pip install -r requirements/dev.txt && \
+uv pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ apt-get install -y gcc && \
 apt-get install -y vim nano htop screen && \
 echo "export PYTHONPATH=${PWD}:$PYTHONPATH" >> /root/.bashrc && \
 pip3 install uv \
-uv pip install -r requirements/dev.txt && \
-uv pip install -e .
+uv pip install --system -r requirements/dev.txt && \
+uv pip install --system -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ apt-get install -y --reinstall build-essential && \
 apt-get install -y gcc && \
 apt-get install -y vim nano htop screen && \
 echo "export PYTHONPATH=${PWD}:$PYTHONPATH" >> /root/.bashrc && \
-pip3 install uv \
+pip3 install uv && \
 uv pip install --system -r requirements/dev.txt && \
 uv pip install --system -e .

--- a/snowshu/adapters/source_adapters/snowflake_adapter.py
+++ b/snowshu/adapters/source_adapters/snowflake_adapter.py
@@ -44,7 +44,6 @@ class SnowflakeAdapter(BaseSourceAdapter):
     ALLOWED_CREDENTIALS = (SCHEMA, WAREHOUSE, ROLE,)
     # snowflake in-db is UPPER, but connector is actually lower :(
     DEFAULT_CASE = 'upper'
-    SNOWFLAKE_MAX_NUMBER_EXPR = 16384
 
     DATA_TYPE_MAPPINGS = {
         "array": dtypes.JSON,
@@ -378,7 +377,6 @@ LIMIT {max_number_of_outliers})
             constraint_query = (
                 f"    SELECT DISTINCT {remote_key} "
                 f"    FROM {relation.temp_dot_notation} "
-                f"    LIMIT {SnowflakeAdapter.SNOWFLAKE_MAX_NUMBER_EXPR}"
             )
             self._validate_key_index_error(relation, constraint_query, remote_key)
             return f"{local_key} IN ({constraint_query})"

--- a/snowshu/core/compile.py
+++ b/snowshu/core/compile.py
@@ -66,7 +66,7 @@ class RuntimeSourceCompiler:
                     edge = dag.edges[parent, relation, key]
                     # if any incoming edge is bidirectional or polymorphic set do_not_sample flag
                     # do_not_sample is set since those types are most likely already restricted
-                    do_not_sample = (edge['direction'] in ('bidirectional', 'polymorphic',) or do_not_sample)
+                    do_not_sample = (edge['direction'] in ('polymorphic',) or do_not_sample)
                     if edge['direction'] == 'polymorphic':
                         # if the local type attribute is set, the constraint needs to account for it
                         # otherwise we only need the normal predicate constraint

--- a/tests/unit/test_snowflake_adapter.py
+++ b/tests/unit/test_snowflake_adapter.py
@@ -193,9 +193,9 @@ def test_predicate_constraint_statement_analyze_false_quoted_non_empty_constrain
     mock_relation.temp_dot_notation = 'mock_dot_notation'
     mock_query.return_value = DataFrame(['1, 2, 3'])
     result = sf.predicate_constraint_statement(mock_relation, False, 'local_key', 'remote_key')
-    assert query_equalize(result) == query_equalize("local_key IN ( SELECT DISTINCT remote_key::VARCHAR FROM mock_dot_notation LIMIT 16384) ")
+    assert query_equalize(result) == query_equalize("local_key IN ( SELECT DISTINCT remote_key::VARCHAR FROM mock_dot_notation )")
 
-    
+
 @mock.patch("snowshu.adapters.source_adapters.snowflake_adapter.SnowflakeAdapter.format_remote_key")
 @mock.patch(
     "snowshu.adapters.source_adapters.snowflake_adapter.SnowflakeAdapter._safe_query"
@@ -213,7 +213,7 @@ def test_predicate_constraint_statement_analyze_false_unquoted_non_empty_constra
         mock_relation, False, "local_key", "remote_key"
     )
     assert query_equalize(result) == query_equalize(
-        "local_key IN ( SELECT DISTINCT remote_key FROM mock_dot_notation LIMIT 16384) "
+        "local_key IN ( SELECT DISTINCT remote_key FROM mock_dot_notation ) "
     )
 
 
@@ -243,8 +243,8 @@ def test_predicate_constraint_statement_analyze_false_key_error(mock_relation, m
     mock_safe_query.side_effect = KeyError()
     with pytest.raises(KeyError, match=r"Remote key remote_key not found in mock_dot_notation table."):
         sf.predicate_constraint_statement(mock_relation, False, 'local_key', 'remote_key')
-        
-@mock.patch('snowshu.adapters.source_adapters.snowflake_adapter.SnowflakeAdapter._safe_query')    
+
+@mock.patch('snowshu.adapters.source_adapters.snowflake_adapter.SnowflakeAdapter._safe_query')
 @mock.patch("snowshu.core.models.relation.Relation")
 def test_format_remote_key_quoted(mock_relation, mock_query):
     """ Verifies that the remote key values is formatted to VARCHAR if it's a type that requires quotes """
@@ -269,8 +269,8 @@ def test_format_remote_key_unquoted(mock_relation, mock_query):
     mock_query.return_value = DataFrame({"data_type": ["NUMBER"]})
     remote_key = "rkey"
     result = sf.format_remote_key(mock_relation, remote_key)
-    assert result == f'{remote_key}::VARCHAR'    
-    
+    assert result == f'{remote_key}::VARCHAR'
+
 
 def test_retry_count_query():
     """ Verifies that the retry decorator works as expected """


### PR DESCRIPTION
Below relation is causing a following issue: `ValueError: failure in building row for relation DATA_LAKE.GOOGLE_ADS_CURRENT.GOOGLE_ADS_CURRENT_GEO_PERFORMANCE_REPORT : 'Relation' object has no attribute 'sample_size'` 

```
    - database: DATA_LAKE
      schema: GOOGLE_ADS_CURRENT
      relation: "(?i)^GOOGLE_ADS_CURRENT_(AD_PERFORMANCE_REPORT|AGE_RANGE_PERFORMANCE_REPORT|GEO_PERFORMANCE_REPORT|GENDER_PERFORMANCE_REPORT|KEYWORDS_PERFORMANCE_REPORT|SEARCH_QUERY_PERFORMANCE_REPORT|USER_LOCATION_PERFORMANCE_REPORT)$"
      relationships:
        bidirectional:
          - local_attribute: AD_GROUP_ID
            database: DATA_LAKE
            schema: GOOGLE_ADS_CURRENT
            relation: GOOGLE_ADS_CURRENT_AD_GROUPS
            remote_attribute: ID
```

From my research it seems like the reason is setting ```do_not_sample``` for ```bidirectional``` relations, I think that initially we assumed that building a predicate eg. ```ID IN (SELECT DISTINCT CONTACT_ID FROM SAMPLED_TABLE)``` is going to be enough to narrow down the upstream dataset. Meanwhile the relation above has a table where this assumption is not fulfilled and the predicate is not enough to narrow down/sample upstream table, resulting in error. I offered the simplest solution with removing the assumption and running sampling each time, though I think if we'd want to stand by the current approach we can add some exception handling where we run this sampling for bidirectional only if we catch the exception of TooManyRecords. I'm dropping this quick solution now to discuss and will be working/testing in the meantime on the other solution. 

Ps. I'll adjust tests once we agree on the solution. 